### PR TITLE
Make the max download size parametrizable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LayerChart v2 API documentation (`docs/libs/layercharts.md`) for LLM-friendly chart development
 
 ### Changed
+- Proxy body size limit made configurable via `network.max_body_size_mb` setting (default 1024 MB), allowing for large file downloads while preventing unbounded transfers.
 - Asset resolution in macOS app bundle now searches multiple paths in `Resources` (including nested Tauri v2 paths) for better reliability.
 - Integration test isolated from host user settings and correctly maps `GOOGLE_API_KEY` to `GEMINI_API_KEY` for the internal VM CLI.
 - Tauri asset bundling now uses a flat map to prevent deeply nested `_up_/_up_/assets` structures in the final package.

--- a/config/defaults.toml
+++ b/config/defaults.toml
@@ -202,11 +202,27 @@ type = "bool"
 default = true
 
 [settings.registry.github.allow.meta]
-domains = ["github.com", "*.github.com", "*.githubusercontent.com"]
+domains = ["github.com", "*.github.com", "*.githubusercontent.com", "objects.githubusercontent.com", "github-releases.githubusercontent.com"]
 
 [settings.registry.github.allow.meta.rules.default]
 get = true
 post = true
+
+[settings.registry.debian]
+name = "Debian"
+description = "Debian package repositories"
+
+[settings.registry.debian.allow]
+name = "Allow Debian"
+description = "Enable access to deb.debian.org and security.debian.org."
+type = "bool"
+default = true
+
+[settings.registry.debian.allow.meta]
+domains = ["deb.debian.org", "security.debian.org"]
+
+[settings.registry.debian.allow.meta.rules.default]
+get = true
 
 [settings.registry.npm]
 name = "npm"
@@ -400,6 +416,16 @@ name = "Custom blocked domains"
 description = "Comma-separated domain patterns to block. Takes priority over custom allow list."
 type = "text"
 default = ""
+
+[settings.network.max_body_size_mb]
+name = "Max transfer size"
+description = "Maximum body size in Megabytes (MB) for network requests/responses. Default 1024 (1GB)."
+type = "number"
+default = 1024
+
+[settings.network.max_body_size_mb.meta]
+min = 0
+max = 102400
 
 # -- VM ----------------------------------------------------------------------
 

--- a/crates/capsem-core/src/net/policy.rs
+++ b/crates/capsem-core/src/net/policy.rs
@@ -82,10 +82,14 @@ pub struct NetworkPolicy {
     pub log_bodies: bool,
     /// Maximum bytes of body preview to capture in telemetry.
     pub max_body_capture: usize,
+    /// Maximum total body size allowed through the proxy (in MB).
+    pub max_body_size_mb: u64,
 }
 
 /// Default max body capture size (4 KB).
 const DEFAULT_MAX_BODY_CAPTURE: usize = 4096;
+/// Default max body transfer size (100 MB).
+const DEFAULT_MAX_BODY_SIZE_MB: u64 = 100;
 
 impl NetworkPolicy {
     /// Create a policy with explicit rules and defaults.
@@ -100,6 +104,7 @@ impl NetworkPolicy {
             default_allow_write,
             log_bodies: true,
             max_body_capture: DEFAULT_MAX_BODY_CAPTURE,
+            max_body_size_mb: DEFAULT_MAX_BODY_SIZE_MB,
         }
     }
 

--- a/crates/capsem-core/src/net/policy_config.rs
+++ b/crates/capsem-core/src/net/policy_config.rs
@@ -1181,9 +1181,16 @@ pub fn load_merged_network_policy() -> super::policy::NetworkPolicy {
         .and_then(|s| s.effective_value.as_number())
         .unwrap_or(4096) as usize;
 
+    let max_body_size = resolved
+        .iter()
+        .find(|s| s.id == "network.max_body_size_mb")
+        .and_then(|s| s.effective_value.as_number())
+        .unwrap_or(1024) as u64;
+
     let mut policy = NetworkPolicy::new(rules, default_action, default_action);
     policy.log_bodies = log_bodies;
     policy.max_body_capture = max_body_capture;
+    policy.max_body_size_mb = max_body_size;
     policy
 }
 


### PR DESCRIPTION
- Add 'network.max_body_size_mb' setting (default 1024MB)
- Allows downloading large artifacts like Electron releases