### PR TITLE
feat: Add headless browser MCP tools for AI agent web automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   Sandbox AI coding agents in hardware-isolated Linux VMs on macOS and Linux.<br/>
-  Full network control, HTTPS inspection, MCP tool routing, and per-session telemetry.
+  Full network control, HTTPS inspection, MCP tool routing, headless browser automation, and per-session telemetry.
 </p>
 
 <p align="center">

--- a/crates/capsem-core/src/mcp/browser_tools.rs
+++ b/crates/capsem-core/src/mcp/browser_tools.rs
@@ -1,0 +1,1243 @@
+//! Headless browser MCP tools for AI agent web automation.
+//!
+//! Provides browser automation capabilities via Playwright, enabling
+//! AI agents running inside the VM to interact with web pages through
+//! MCP tools. The browser runs on the host for security and performance.
+//!
+//! Tools provided:
+//! - `browser_navigate`: Navigate to a URL
+//! - `browser_click`: Click an element by CSS selector
+//! - `browser_type`: Type text into an input field
+//! - `browser_screenshot`: Capture a screenshot of the current page
+//! - `browser_evaluate`: Execute JavaScript and return the result
+//! - `browser_get_text`: Extract text content from an element
+//! - `browser_fill_form`: Fill multiple form fields at once
+//! - `browser_get_content`: Get the page HTML or text content
+//! - `browser_close`: Close the browser session
+
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+use capsem_logger::{DbWriter, WriteOp};
+
+use super::builtin_tools::DEFAULT_MAX_LENGTH;
+use super::types::{JsonRpcResponse, McpToolDef, ToolAnnotations};
+
+/// Browser tool names (without namespace prefix).
+const BROWSER_TOOL_NAMES: &[&str] = &[
+    "browser_navigate",
+    "browser_click",
+    "browser_type",
+    "browser_screenshot",
+    "browser_evaluate",
+    "browser_get_text",
+    "browser_fill_form",
+    "browser_get_content",
+    "browser_close",
+];
+
+/// Check if a tool name is a browser tool.
+pub fn is_browser_tool(name: &str) -> bool {
+    BROWSER_TOOL_NAMES.contains(&name)
+}
+
+/// Playwright server process wrapper.
+struct PlaywrightServer {
+    /// Child process handle
+    child: tokio::process::Child,
+    /// WebSocket endpoint URL
+    ws_endpoint: String,
+    /// HTTP client for sending commands to Playwright server
+    http_client: reqwest::Client,
+}
+
+impl PlaywrightServer {
+    /// Start a new Playwright server process.
+    async fn start() -> Result<Self, String> {
+        // Write the embedded JS to a temp file
+        let script_content = include_str!("playwright_server.js");
+        let temp_dir = std::env::temp_dir();
+        let script_path = temp_dir.join(format!("capsem_playwright_{}.js", uuid::Uuid::new_v4()));
+
+        tokio::fs::write(&script_path, script_content)
+            .await
+            .map_err(|e| format!("Failed to write Playwright script: {}", e))?;
+
+        let script_path_clone = script_path.clone();
+
+        // Start Node.js Playwright server subprocess
+        let mut child = Command::new("node")
+            .arg(&script_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                let _ = std::fs::remove_file(&script_path);
+                format!("Failed to start Playwright server: {}. Ensure Node.js and Playwright are installed (run 'npx playwright install').", e)
+            })?;
+
+        // Read stdout to get WebSocket endpoint
+        let stdout = child.stdout.take().ok_or("Failed to capture stdout")?;
+        let mut reader = BufReader::new(stdout);
+
+        let mut ws_endpoint = String::new();
+        let mut error_output = String::new();
+
+        // Wait for WebSocket endpoint URL with timeout
+        let timeout = Duration::from_secs(30);
+        let start = Instant::now();
+
+        loop {
+            if start.elapsed() > timeout {
+                let _ = child.kill().await;
+                let _ = std::fs::remove_file(&script_path);
+                return Err("Playwright server startup timeout (30s)".to_string());
+            }
+
+            // Try reading a line with timeout
+            let mut line = String::new();
+            match tokio::time::timeout(Duration::from_millis(100), reader.read_line(&mut line))
+                .await
+            {
+                Ok(Ok(n)) => {
+                    if n > 0 {
+                        let trimmed = line.trim();
+                        if trimmed.starts_with("ws://") {
+                            ws_endpoint = trimmed.to_string();
+                            break;
+                        }
+                        // Collect stderr output for error messages
+                        error_output.push_str(trimmed);
+                        error_output.push('\n');
+                    } else {
+                        // EOF - process exited
+                        let status = child.try_wait().map_err(|e| {
+                            let _ = std::fs::remove_file(&script_path);
+                            format!("Failed to check status: {}", e)
+                        })?;
+                        if let Some(status) = status {
+                            let _ = std::fs::remove_file(&script_path);
+                            return Err(format!(
+                                "Playwright server exited with status: {}\nError output:\n{}",
+                                status, error_output
+                            ));
+                        }
+                    }
+                }
+                Ok(Err(e)) => {
+                    let _ = std::fs::remove_file(&script_path);
+                    return Err(format!("Failed to read stdout: {}", e));
+                }
+                Err(_) => continue, // Timeout on this iteration, retry
+            }
+        }
+
+        let http_client = reqwest::Client::new();
+
+        // Spawn a background task to clean up the temp file when process exits
+        let cleanup_path = script_path_clone.clone();
+        tokio::spawn(async move {
+            // Wait for child process to exit, then cleanup
+            // (we can't access child here, so just schedule cleanup)
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            let _ = tokio::fs::remove_file(&cleanup_path).await;
+        });
+
+        Ok(Self {
+            child,
+            ws_endpoint,
+            http_client,
+        })
+    }
+
+    /// Execute a Playwright command via HTTP API.
+    async fn execute_command(
+        &self,
+        action: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        let payload = serde_json::json!({
+            "action": action,
+            "params": params
+        });
+
+        // Convert ws:// to http:// for HTTP requests
+        let url = format!("{}/execute", self.ws_endpoint.replace("ws://", "http://"));
+
+        let resp = self
+            .http_client
+            .post(&url)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("Playwright server error: {}\n{}", status, body));
+        }
+
+        let result: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+        if let Some(error) = result.get("error") {
+            return Err(error.as_str().unwrap_or("Unknown error").to_string());
+        }
+
+        result
+            .get("result")
+            .cloned()
+            .ok_or_else(|| "No result in response".to_string())
+    }
+
+    /// Shutdown the Playwright server process and cleanup temp file.
+    async fn shutdown(&mut self) {
+        if let Err(e) = self.child.kill().await {
+            tracing::warn!(error = %e, "Failed to kill Playwright server process");
+        }
+        // Temp file will be cleaned up by background task or OS
+    }
+}
+
+impl Drop for PlaywrightServer {
+    fn drop(&mut self) {
+        // Ensure process is cleaned up on drop
+        let _ = self.child.start_kill();
+    }
+}
+
+/// Browser session state.
+pub struct BrowserSession {
+    /// Playwright server instance
+    server: Option<PlaywrightServer>,
+    /// Session created timestamp
+    created_at: Instant,
+}
+
+impl BrowserSession {
+    /// Create a new browser session (lazily initializes Playwright).
+    pub async fn new() -> Result<Self, String> {
+        Ok(Self {
+            server: None,
+            created_at: Instant::now(),
+        })
+    }
+
+    /// Get or initialize the Playwright server.
+    pub async fn get_server(&mut self) -> Result<&PlaywrightServer, String> {
+        if self.server.is_none() {
+            let server = PlaywrightServer::start().await?;
+            self.server = Some(server);
+        }
+        Ok(self.server.as_ref().unwrap())
+    }
+
+    /// Get mutable reference to server for shutdown.
+    pub async fn get_server_mut(&mut self) -> Result<&mut PlaywrightServer, String> {
+        if self.server.is_none() {
+            let server = PlaywrightServer::start().await?;
+            self.server = Some(server);
+        }
+        Ok(self.server.as_mut().unwrap())
+    }
+
+    /// Check if browser is initialized.
+    pub fn is_initialized(&self) -> bool {
+        self.server.is_some()
+    }
+
+    /// Shutdown the browser session.
+    pub async fn shutdown(&mut self) {
+        if let Some(ref mut server) = self.server {
+            server.shutdown().await;
+        }
+    }
+}
+
+/// Global browser session manager.
+pub struct BrowserManager {
+    /// Current active session (if any)
+    session: Mutex<Option<BrowserSession>>,
+    /// Logger for telemetry
+    db: Arc<DbWriter>,
+}
+
+impl BrowserManager {
+    /// Create a new browser manager.
+    pub fn new(db: Arc<DbWriter>) -> Self {
+        Self {
+            session: Mutex::new(None),
+            db,
+        }
+    }
+
+    /// Get server reference, initializing session if needed.
+    async fn get_server(&self) -> Result<&PlaywrightServer, String> {
+        let mut session_lock = self.session.lock().await;
+        if session_lock.is_none() {
+            *session_lock = Some(BrowserSession::new().await?);
+        }
+        let session = session_lock.as_mut().unwrap();
+        session.get_server().await
+    }
+
+    /// Execute a command on the browser.
+    pub async fn execute_command(
+        &self,
+        action: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        // We need mutable access to session for get_server_mut
+        drop(self.session.lock().await); // Release previous lock
+        let mut session_lock = self.session.lock().await;
+        if session_lock.is_none() {
+            *session_lock = Some(BrowserSession::new().await?);
+        }
+        let session = session_lock.as_mut().unwrap();
+        let server = session.get_server().await?;
+        server.execute_command(action, params).await
+    }
+
+    /// Close current browser session.
+    pub async fn close_session(&self) {
+        let mut session_lock = self.session.lock().await;
+        if let Some(ref mut session) = *session_lock {
+            session.shutdown().await;
+        }
+        *session_lock = None;
+    }
+}
+
+/// Return browser tool definitions.
+pub fn browser_tool_defs() -> Vec<McpToolDef> {
+    vec![
+        McpToolDef {
+            namespaced_name: "browser_navigate".into(),
+            original_name: "browser_navigate".into(),
+            description: Some(concat!(
+                "Navigate the browser to a URL. ",
+                "Opens the specified URL in a headless browser and waits for the page to load. ",
+                "Returns the page title, final URL (after redirects), and a summary of the page content. ",
+                "Use this before other browser tools to load a page. ",
+                "Errors: invalid URL, navigation timeout, page load failure."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "The URL to navigate to. Must include http:// or https:// protocol."
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Navigation timeout in milliseconds (default: 30000). Increase for slow pages."
+                    },
+                    "wait_until": {
+                        "type": "string",
+                        "enum": ["load", "domcontentloaded", "networkidle"],
+                        "description": "When to consider navigation succeeded (default: 'load'). 'load': wait for load event. 'domcontentloaded': wait for DOMContentLoaded. 'networkidle': wait until no network connections for 500ms."
+                    }
+                },
+                "required": ["url"]
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Navigate".into()),
+                read_only_hint: true,
+                destructive_hint: false,
+                idempotent_hint: true,
+                open_world_hint: true,
+            }),
+        },
+        McpToolDef {
+            namespaced_name: "browser_click".into(),
+            original_name: "browser_click".into(),
+            description: Some(concat!(
+                "Click an element on the page by CSS selector. ",
+                "Finds the element matching the selector and performs a click action. ",
+                "Useful for clicking links, buttons, form elements, and interactive elements. ",
+                "Common selectors: 'a[href=\"/path\"]', 'button:has-text(\"Submit\")', '#submit-btn', '.nav-item'. ",
+                "Returns success message or error if element not found. ",
+                "Errors: element not found, element not visible, click intercepted."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "selector": {
+                        "type": "string",
+                        "description": "CSS selector for the element to click. Examples: 'button', '#my-id', '.my-class', 'a[href=\"/link\"]'."
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Timeout in milliseconds to wait for element to appear (default: 5000)."
+                    }
+                },
+                "required": ["selector"]
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Click".into()),
+                read_only_hint: false,
+                destructive_hint: false,
+                idempotent_hint: false,
+                open_world_hint: true,
+            }),
+        },
+        McpToolDef {
+            namespaced_name: "browser_type".into(),
+            original_name: "browser_type".into(),
+            description: Some(concat!(
+                "Type text into an input field on the page. ",
+                "Finds the input element by CSS selector and types the specified text. ",
+                "Works with <input>, <textarea>, and [contenteditable] elements. ",
+                "Supports special keys using caret notation: 'Enter', 'Tab', 'Backspace', 'ArrowLeft', etc. ",
+                "Example: 'Hello World' or 'username{tab}password{enter}'. ",
+                "Returns success message or error if element not found. ",
+                "Errors: element not found, element not an input, type failure."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "selector": {
+                        "type": "string",
+                        "description": "CSS selector for the input element. Examples: 'input[name=\"username\"]', '#search-box', 'textarea'."
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Text to type into the input. Use {Enter}, {Tab}, etc. for special keys."
+                    },
+                    "clear_first": {
+                        "type": "boolean",
+                        "description": "Whether to clear existing text before typing (default: true)."
+                    }
+                },
+                "required": ["selector", "text"]
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Type".into()),
+                read_only_hint: false,
+                destructive_hint: false,
+                idempotent_hint: false,
+                open_world_hint: true,
+            }),
+        },
+        McpToolDef {
+            namespaced_name: "browser_screenshot".into(),
+            original_name: "browser_screenshot".into(),
+            description: Some(concat!(
+                "Capture a screenshot of the current page or a specific element. ",
+                "Returns a base64-encoded PNG image that can be displayed or analyzed. ",
+                "Optionally capture only a specific element using a CSS selector. ",
+                "Useful for visual verification, debugging layouts, or reading content. ",
+                "Returns base64 PNG data with dimensions. ",
+                "Errors: page not loaded, element not found, screenshot failure."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "selector": {
+                        "type": "string",
+                        "description": "CSS selector for a specific element to screenshot. If omitted, captures the full page."
+                    },
+                    "full_page": {
+                        "type": "boolean",
+                        "description": "Capture full scrollable page instead of viewport (default: false)."
+                    },
+                    "max_width": {
+                        "type": "integer",
+                        "description": "Maximum width in pixels (default: 1280). Scales down if larger."
+                    }
+                }
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Screenshot".into()),
+                read_only_hint: true,
+                destructive_hint: false,
+                idempotent_hint: true,
+                open_world_hint: false,
+            }),
+        },
+        McpToolDef {
+            namespaced_name: "browser_evaluate".into(),
+            original_name: "browser_evaluate".into(),
+            description: Some(concat!(
+                "Execute JavaScript code in the browser context and return the result. ",
+                "The code runs in the page's JavaScript environment with access to the DOM. ",
+                "Can return primitive values, objects, or DOM element references. ",
+                "Example: 'document.title' or 'document.querySelectorAll(\"a\").length'. ",
+                "Returns the serialized result as JSON. ",
+                "Errors: JavaScript syntax error, execution timeout, page not loaded."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "javascript": {
+                        "type": "string",
+                        "description": "JavaScript code to execute. Can access document, window, and DOM APIs. Example: 'document.title' or 'Array.from(document.querySelectorAll(\"h2\")).map(h => h.textContent)'."
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Execution timeout in milliseconds (default: 10000)."
+                    }
+                },
+                "required": ["javascript"]
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Evaluate".into()),
+                read_only_hint: false,
+                destructive_hint: true,
+                idempotent_hint: false,
+                open_world_hint: true,
+            }),
+        },
+        McpToolDef {
+            namespaced_name: "browser_get_text".into(),
+            original_name: "browser_get_text".into(),
+            description: Some(concat!(
+                "Extract text content from elements matching a CSS selector. ",
+                "Returns the visible text from all matching elements, trimmed and cleaned. ",
+                "Useful for reading article content, form labels, navigation items, etc. ",
+                "Example selector: 'h1', '.article-body', 'nav a', '#content p'. ",
+                "Returns text with one entry per matching element. ",
+                "Errors: element not found, page not loaded, extraction failure."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "selector": {
+                        "type": "string",
+                        "description": "CSS selector for elements to extract text from. Examples: 'h1', '.content', 'p', '#main-text'."
+                    },
+                    "max_length": {
+                        "type": "integer",
+                        "description": "Maximum characters to return (default: 5000). Truncates if longer."
+                    }
+                },
+                "required": ["selector"]
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Get Text".into()),
+                read_only_hint: true,
+                destructive_hint: false,
+                idempotent_hint: true,
+                open_world_hint: false,
+            }),
+        },
+        McpToolDef {
+            namespaced_name: "browser_fill_form".into(),
+            original_name: "browser_fill_form".into(),
+            description: Some(concat!(
+                "Fill multiple form fields at once. ",
+                "Finds each input by its CSS selector and sets its value. ",
+                "More efficient than calling browser_type multiple times for forms. ",
+                "Supports text inputs, textareas, selects, checkboxes, and radio buttons. ",
+                "Each field is an object with 'selector' and 'value' keys. ",
+                "Example: [{\"selector\": \"#username\", \"value\": \"user\"}, {\"selector\": \"#password\", \"value\": \"pass\"}]. ",
+                "Returns success message with count of fields filled or error on first failure. ",
+                "Errors: field not found, invalid field type, fill failure."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "fields": {
+                        "type": "array",
+                        "description": "Array of field objects, each with 'selector' and 'value' properties.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "selector": {
+                                    "type": "string",
+                                    "description": "CSS selector for the input element."
+                                },
+                                "value": {
+                                    "type": "string",
+                                    "description": "Value to set in the field."
+                                }
+                            },
+                            "required": ["selector", "value"]
+                        }
+                    }
+                },
+                "required": ["fields"]
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Fill Form".into()),
+                read_only_hint: false,
+                destructive_hint: false,
+                idempotent_hint: false,
+                open_world_hint: true,
+            }),
+        },
+        McpToolDef {
+            namespaced_name: "browser_get_content".into(),
+            original_name: "browser_get_content".into(),
+            description: Some(concat!(
+                "Get the page content as HTML or text. ",
+                "Returns either the full page HTML, or cleaned text content. ",
+                "Useful for scraping, verifying content, or extracting data. ",
+                "Optionally target a specific element with a CSS selector. ",
+                "Returns content with metadata (URL, content length). ",
+                "Errors: page not loaded, selector not found, extraction failure."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "selector": {
+                        "type": "string",
+                        "description": "CSS selector for a specific element. If omitted, returns full page content."
+                    },
+                    "format": {
+                        "type": "string",
+                        "enum": ["html", "text"],
+                        "description": "Output format: 'html' returns the HTML markup, 'text' (default) returns visible text only."
+                    },
+                    "max_length": {
+                        "type": "integer",
+                        "description": "Maximum characters to return (default: 5000)."
+                    }
+                }
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Get Content".into()),
+                read_only_hint: true,
+                destructive_hint: false,
+                idempotent_hint: true,
+                open_world_hint: false,
+            }),
+        },
+        McpToolDef {
+            namespaced_name: "browser_close".into(),
+            original_name: "browser_close".into(),
+            description: Some(concat!(
+                "Close the browser session and free resources. ",
+                "Closes all pages and the browser instance. ",
+                "Use when done with web automation to clean up. ",
+                "Returns success message. Safe to call even if browser is not initialized. ",
+                "No parameters required."
+            ).into()),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {}
+            }),
+            server_name: "browser".into(),
+            annotations: Some(ToolAnnotations {
+                title: Some("Browser Close".into()),
+                read_only_hint: true,
+                destructive_hint: true,
+                idempotent_hint: true,
+                open_world_hint: false,
+            }),
+        },
+    ]
+}
+
+/// Dispatch a browser tool call by local name.
+pub async fn call_browser_tool(
+    local_name: &str,
+    arguments: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    request_id: Option<Value>,
+    db: &Arc<DbWriter>,
+) -> JsonRpcResponse {
+    let start = Instant::now();
+    let result = match local_name {
+        "browser_navigate" => {
+            handle_browser_navigate(arguments, browser_manager, request_id.clone()).await
+        }
+        "browser_click" => {
+            handle_browser_click(arguments, browser_manager, request_id.clone()).await
+        }
+        "browser_type" => handle_browser_type(arguments, browser_manager, request_id.clone()).await,
+        "browser_screenshot" => {
+            handle_browser_screenshot(arguments, browser_manager, request_id.clone()).await
+        }
+        "browser_evaluate" => {
+            handle_browser_evaluate(arguments, browser_manager, request_id.clone()).await
+        }
+        "browser_get_text" => {
+            handle_browser_get_text(arguments, browser_manager, request_id.clone()).await
+        }
+        "browser_fill_form" => {
+            handle_browser_fill_form(arguments, browser_manager, request_id.clone()).await
+        }
+        "browser_get_content" => {
+            handle_browser_get_content(arguments, browser_manager, request_id.clone()).await
+        }
+        "browser_close" => handle_browser_close(browser_manager, request_id.clone()).await,
+        _ => JsonRpcResponse::err(
+            request_id.clone(),
+            -32602,
+            format!("unknown browser tool: {local_name}"),
+        ),
+    };
+
+    // Log the browser call
+    let duration_ms = start.elapsed().as_millis() as u64;
+    log_browser_call(db, local_name, arguments, &result, duration_ms).await;
+
+    result
+}
+
+/// Log a browser call to the session database.
+async fn log_browser_call(
+    db: &Arc<DbWriter>,
+    tool_name: &str,
+    arguments: &Value,
+    result: &JsonRpcResponse,
+    duration_ms: u64,
+) {
+    let request_preview = serde_json::to_string(arguments).ok();
+    let resp_preview = result
+        .result
+        .as_ref()
+        .and_then(|r| serde_json::to_string(r).ok());
+
+    let bytes_sent = serde_json::to_vec(arguments)
+        .ok()
+        .map(|v| v.len() as u64)
+        .unwrap_or(0);
+
+    let bytes_received = result
+        .result
+        .as_ref()
+        .and_then(|r| serde_json::to_vec(r).ok())
+        .map(|v| v.len() as u64)
+        .unwrap_or(0);
+
+    db.write(WriteOp::McpCall(capsem_logger::McpCall {
+        timestamp: std::time::SystemTime::now(),
+        server_name: "browser".to_string(),
+        method: "tools/call".to_string(),
+        tool_name: Some(tool_name.to_string()),
+        request_id: None,
+        request_preview,
+        response_preview: resp_preview,
+        decision: if result.error.is_some() {
+            "error"
+        } else {
+            "allowed"
+        }
+        .to_string(),
+        duration_ms,
+        error_message: result.error.as_ref().map(|e| e.message.clone()),
+        process_name: Some("browser".to_string()),
+        bytes_sent,
+        bytes_received,
+    }))
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Browser tool handlers
+// ---------------------------------------------------------------------------
+
+async fn handle_browser_navigate(
+    args: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    let url = match args.get("url").and_then(|v| v.as_str()) {
+        Some(u) => u,
+        None => return tool_error(id, "missing required parameter: url"),
+    };
+
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return tool_error(id, "URL must start with http:// or https://");
+    }
+
+    let timeout = args
+        .get("timeout")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(30000);
+    let wait_until = args
+        .get("wait_until")
+        .and_then(|v| v.as_str())
+        .unwrap_or("load");
+
+    match browser_manager
+        .execute_command(
+            "navigate",
+            serde_json::json!({
+                "url": url,
+                "timeout": timeout,
+                "waitUntil": wait_until,
+            }),
+        )
+        .await
+    {
+        Ok(result) => {
+            let output = format!(
+                "Navigated to: {}\nFinal URL: {}\nTitle: {}\nStatus: {}",
+                url,
+                result.get("url").and_then(|v| v.as_str()).unwrap_or(url),
+                result
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Unknown"),
+                result.get("status").and_then(|v| v.as_u64()).unwrap_or(0),
+            );
+            tool_ok(id, &output)
+        }
+        Err(e) => tool_error(id, &e),
+    }
+}
+
+async fn handle_browser_click(
+    args: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    let selector = match args.get("selector").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return tool_error(id, "missing required parameter: selector"),
+    };
+    let timeout = args.get("timeout").and_then(|v| v.as_u64()).unwrap_or(5000);
+
+    match browser_manager
+        .execute_command(
+            "click",
+            serde_json::json!({
+                "selector": selector,
+                "timeout": timeout,
+            }),
+        )
+        .await
+    {
+        Ok(_) => tool_ok(id, &format!("Clicked: {}", selector)),
+        Err(e) => tool_error(id, &e),
+    }
+}
+
+async fn handle_browser_type(
+    args: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    let selector = match args.get("selector").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return tool_error(id, "missing required parameter: selector"),
+    };
+    let text = match args.get("text").and_then(|v| v.as_str()) {
+        Some(t) => t,
+        None => return tool_error(id, "missing required parameter: text"),
+    };
+    let clear_first = args
+        .get("clear_first")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+
+    match browser_manager
+        .execute_command(
+            "type",
+            serde_json::json!({
+                "selector": selector,
+                "text": text,
+                "clearFirst": clear_first,
+            }),
+        )
+        .await
+    {
+        Ok(_) => tool_ok(id, &format!("Typed '{}' into: {}", text, selector)),
+        Err(e) => tool_error(id, &e),
+    }
+}
+
+async fn handle_browser_screenshot(
+    args: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    let selector = args.get("selector").and_then(|v| v.as_str());
+    let full_page = args
+        .get("full_page")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let max_width = args
+        .get("max_width")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(1280);
+
+    let mut params = serde_json::json!({
+        "fullPage": full_page,
+        "maxWidth": max_width,
+    });
+    if let Some(sel) = selector {
+        params["selector"] = serde_json::Value::String(sel.to_string());
+    }
+
+    match browser_manager.execute_command("screenshot", params).await {
+        Ok(result) => {
+            let image = result.get("image").and_then(|v| v.as_str()).unwrap_or("");
+            let width = result.get("width").and_then(|v| v.as_u64()).unwrap_or(0);
+            let output = format!(
+                "Screenshot captured\nWidth: {} px\nFormat: png\nSize: {} bytes\n\ndata:image/png;base64,{}",
+                width,
+                image.len(),
+                image
+            );
+            tool_ok(id, &output)
+        }
+        Err(e) => tool_error(id, &e),
+    }
+}
+
+async fn handle_browser_evaluate(
+    args: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    let javascript = match args.get("javascript").and_then(|v| v.as_str()) {
+        Some(j) => j,
+        None => return tool_error(id, "missing required parameter: javascript"),
+    };
+    let timeout = args
+        .get("timeout")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(10000);
+
+    match browser_manager
+        .execute_command(
+            "evaluate",
+            serde_json::json!({
+                "javascript": javascript,
+                "timeout": timeout,
+            }),
+        )
+        .await
+    {
+        Ok(result) => {
+            let output = format!(
+                "Executed JavaScript: {}\n\nResult:\n{}",
+                javascript,
+                serde_json::to_string_pretty(
+                    &result.get("result").unwrap_or(&serde_json::Value::Null)
+                )
+                .unwrap_or_default()
+            );
+            tool_ok(id, &output)
+        }
+        Err(e) => tool_error(id, &e),
+    }
+}
+
+async fn handle_browser_get_text(
+    args: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    let selector = match args.get("selector").and_then(|v| v.as_str()) {
+        Some(s) => s,
+        None => return tool_error(id, "missing required parameter: selector"),
+    };
+    let max_length = args
+        .get("max_length")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(DEFAULT_MAX_LENGTH);
+
+    match browser_manager
+        .execute_command(
+            "getText",
+            serde_json::json!({
+                "selector": selector,
+                "maxLength": max_length,
+            }),
+        )
+        .await
+    {
+        Ok(result) => {
+            let text = result.get("text").and_then(|v| v.as_str()).unwrap_or("");
+            let length = result.get("length").and_then(|v| v.as_u64()).unwrap_or(0);
+            let elements = result
+                .get("elementsFound")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+
+            let (chunk, total, has_more) = paginate(text, 0, max_length as usize);
+            let mut output = format!(
+                "Extracted text from: {}\nElements found: {}\nTotal length: {}\n",
+                selector, elements, total
+            );
+            if has_more {
+                output.push_str(&format!("Showing first {} characters\n", max_length));
+            }
+            output.push('\n');
+            output.push_str(&chunk);
+
+            tool_ok(id, &output)
+        }
+        Err(e) => tool_error(id, &e),
+    }
+}
+
+async fn handle_browser_fill_form(
+    args: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    let fields = match args.get("fields").and_then(|v| v.as_array()) {
+        Some(f) => f,
+        None => return tool_error(id, "missing required parameter: fields (must be an array)"),
+    };
+
+    // Validate fields
+    for (i, field) in fields.iter().enumerate() {
+        if field.get("selector").is_none() || field.get("value").is_none() {
+            return tool_error(id, &format!("field {} missing 'selector' or 'value'", i));
+        }
+    }
+
+    match browser_manager
+        .execute_command(
+            "fillForm",
+            serde_json::json!({
+                "fields": fields,
+            }),
+        )
+        .await
+    {
+        Ok(_) => {
+            let output = format!("Filled {} form fields", fields.len());
+            tool_ok(id, &output)
+        }
+        Err(e) => tool_error(id, &e),
+    }
+}
+
+async fn handle_browser_get_content(
+    args: &Value,
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    let format = args
+        .get("format")
+        .and_then(|v| v.as_str())
+        .unwrap_or("text");
+    let max_length = args
+        .get("max_length")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(DEFAULT_MAX_LENGTH);
+    let selector = args.get("selector").and_then(|v| v.as_str());
+
+    let mut params = serde_json::json!({
+        "format": format,
+        "maxLength": max_length,
+    });
+    if let Some(sel) = selector {
+        params["selector"] = serde_json::Value::String(sel.to_string());
+    }
+
+    match browser_manager.execute_command("getContent", params).await {
+        Ok(result) => {
+            let content = result.get("content").and_then(|v| v.as_str()).unwrap_or("");
+            let length = result.get("length").and_then(|v| v.as_u64()).unwrap_or(0);
+            let fmt = result
+                .get("format")
+                .and_then(|v| v.as_str())
+                .unwrap_or("text");
+
+            let (chunk, total, has_more) = paginate(content, 0, max_length as usize);
+            let mut output = format!("Page content\nFormat: {}\nLength: {}\n", fmt, total);
+            if has_more {
+                output.push_str(&format!("Showing first {} characters\n", max_length));
+            }
+            output.push('\n');
+            output.push_str(&chunk);
+
+            tool_ok(id, &output)
+        }
+        Err(e) => tool_error(id, &e),
+    }
+}
+
+async fn handle_browser_close(
+    browser_manager: &Arc<BrowserManager>,
+    id: Option<Value>,
+) -> JsonRpcResponse {
+    browser_manager.close_session().await;
+    tool_ok(id, "Browser session closed")
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Paginate text content.
+fn paginate(text: &str, start_index: usize, max_length: usize) -> (String, usize, bool) {
+    let total = text.len();
+    if start_index >= total {
+        return (String::new(), total, false);
+    }
+
+    let end = (start_index + max_length).min(total);
+    let has_more = end < total;
+    let chunk = text[start_index..end].to_string();
+
+    (chunk, total, has_more)
+}
+
+/// Create a successful tool response.
+fn tool_ok(id: Option<Value>, output: &str) -> JsonRpcResponse {
+    JsonRpcResponse::ok(
+        id,
+        serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": output
+                }
+            ]
+        }),
+    )
+}
+
+/// Create an error tool response.
+fn tool_error(id: Option<Value>, message: &str) -> JsonRpcResponse {
+    JsonRpcResponse::err(id, -32603, message.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_browser_tool_basic() {
+        assert!(is_browser_tool("browser_navigate"));
+        assert!(is_browser_tool("browser_click"));
+        assert!(is_browser_tool("browser_close"));
+        assert!(!is_browser_tool("fetch_http"));
+        assert!(!is_browser_tool("unknown"));
+    }
+
+    #[test]
+    fn browser_tool_defs_count() {
+        let defs = browser_tool_defs();
+        assert_eq!(defs.len(), 9);
+        assert!(defs.iter().any(|d| d.namespaced_name == "browser_navigate"));
+        assert!(defs.iter().any(|d| d.namespaced_name == "browser_close"));
+    }
+
+    #[test]
+    fn tool_ok_creates_valid_response() {
+        let resp = tool_ok(Some(serde_json::json!(1)), "test output");
+        assert!(resp.error.is_none());
+        assert!(resp.result.is_some());
+    }
+
+    #[test]
+    fn tool_error_creates_valid_response() {
+        let resp = tool_error(Some(serde_json::json!(1)), "something went wrong");
+        assert!(resp.error.is_some());
+        let err = resp.error.as_ref().unwrap();
+        assert_eq!(err.code, -32603);
+        assert_eq!(err.message, "something went wrong");
+    }
+
+    #[test]
+    fn paginate_basic() {
+        let text = "Hello World";
+        let (chunk, total, has_more) = paginate(text, 0, 5);
+        assert_eq!(chunk, "Hello");
+        assert_eq!(total, 11);
+        assert!(has_more);
+    }
+
+    #[test]
+    fn paginate_no_more() {
+        let text = "Hello";
+        let (chunk, total, has_more) = paginate(text, 0, 10);
+        assert_eq!(chunk, "Hello");
+        assert_eq!(total, 5);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn paginate_start_index_beyond() {
+        let text = "Hello";
+        let (chunk, total, has_more) = paginate(text, 10, 5);
+        assert_eq!(chunk, "");
+        assert_eq!(total, 5);
+        assert!(!has_more);
+    }
+
+    #[test]
+    fn browser_navigate_missing_url() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let db = rt.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test.db");
+            Arc::new(DbWriter::open(&path, 64).unwrap())
+        });
+        let browser_manager = Arc::new(BrowserManager::new(Arc::clone(&db)));
+
+        let resp = rt.block_on(handle_browser_navigate(
+            &serde_json::json!({}),
+            &browser_manager,
+            Some(serde_json::json!(1)),
+        ));
+        assert!(resp.error.is_some());
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("missing required parameter: url"));
+    }
+
+    #[test]
+    fn browser_click_missing_selector() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let db = rt.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test.db");
+            Arc::new(DbWriter::open(&path, 64).unwrap())
+        });
+        let browser_manager = Arc::new(BrowserManager::new(Arc::clone(&db)));
+
+        let resp = rt.block_on(handle_browser_click(
+            &serde_json::json!({}),
+            &browser_manager,
+            Some(serde_json::json!(1)),
+        ));
+        assert!(resp.error.is_some());
+    }
+
+    #[test]
+    fn browser_fill_form_invalid_fields() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let db = rt.block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("test.db");
+            Arc::new(DbWriter::open(&path, 64).unwrap())
+        });
+        let browser_manager = Arc::new(BrowserManager::new(Arc::clone(&db)));
+
+        let resp = rt.block_on(handle_browser_fill_form(
+            &serde_json::json!({"fields": "not_an_array"}),
+            &browser_manager,
+            Some(serde_json::json!(1)),
+        ));
+        assert!(resp.error.is_some());
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("fields (must be an array)"));
+    }
+}

--- a/crates/capsem-core/src/mcp/gateway.rs
+++ b/crates/capsem-core/src/mcp/gateway.rs
@@ -21,6 +21,7 @@ use rmcp::model::{CallToolRequestParams, GetPromptRequestParams, ReadResourceReq
 
 use crate::net::domain_policy::DomainPolicy;
 
+use super::browser_tools;
 use super::builtin_tools;
 use super::policy::{McpPolicy, ToolDecision};
 use super::server_manager::McpServerManager;
@@ -41,9 +42,12 @@ pub struct McpGatewayConfig {
     /// HTTP client for built-in tools.
     pub http_client: reqwest::Client,
     /// Auto-snapshot scheduler for file tools (VirtioFS mode only).
-    pub auto_snapshots: Option<Arc<tokio::sync::Mutex<crate::auto_snapshot::AutoSnapshotScheduler>>>,
+    pub auto_snapshots:
+        Option<Arc<tokio::sync::Mutex<crate::auto_snapshot::AutoSnapshotScheduler>>>,
     /// Workspace directory for file tools (VirtioFS mode only).
     pub workspace_dir: Option<std::path::PathBuf>,
+    /// Browser manager for headless browser tools.
+    pub browser_manager: Option<Arc<browser_tools::BrowserManager>>,
 }
 
 /// Serve a single MCP session over a vsock connection.
@@ -145,8 +149,8 @@ async fn serve_mcp_session_inner(fd: RawFd, config: &McpGatewayConfig) -> Result
         log_mcp_call(config, &request, &response, &process_name, duration_ms).await;
 
         // Send NDJSON response line
-        let mut resp_line = serde_json::to_vec(&response)
-            .context("failed to serialize JSON-RPC response")?;
+        let mut resp_line =
+            serde_json::to_vec(&response).context("failed to serialize JSON-RPC response")?;
         resp_line.push(b'\n');
         write_half.write_all(&resp_line).await?;
     }
@@ -161,32 +165,34 @@ async fn handle_json_rpc(
     _process_name: &str,
 ) -> Option<JsonRpcResponse> {
     match req.method.as_str() {
-        "initialize" => {
-            Some(JsonRpcResponse::ok(
-                req.id.clone(),
-                serde_json::json!({
-                    "protocolVersion": "2024-11-05",
-                    "capabilities": {
-                        "tools": {},
-                        "resources": {},
-                        "prompts": {}
-                    },
-                    "serverInfo": {
-                        "name": "capsem-mcp-gateway",
-                        "version": env!("CARGO_PKG_VERSION")
-                    }
-                }),
-            ))
-        }
+        "initialize" => Some(JsonRpcResponse::ok(
+            req.id.clone(),
+            serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {
+                    "tools": {},
+                    "resources": {},
+                    "prompts": {}
+                },
+                "serverInfo": {
+                    "name": "capsem-mcp-gateway",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }),
+        )),
 
         // Notifications have no id and expect no response.
         "notifications/initialized" => None,
 
         "tools/list" => {
-            // Prepend built-in tools (HTTP + file) before external server tools.
+            // Prepend built-in tools (HTTP + file + browser) before external server tools.
             let mut builtin = builtin_tools::builtin_tool_defs();
             if config.workspace_dir.is_some() {
                 builtin.extend(super::file_tools::file_tool_defs());
+            }
+            // Add browser tools if browser manager is available
+            if config.browser_manager.is_some() {
+                builtin.extend(browser_tools::browser_tool_defs());
             }
             let mgr = config.server_manager.lock().await;
             let tools: Vec<serde_json::Value> = builtin
@@ -204,7 +210,10 @@ async fn handle_json_rpc(
                     tool
                 })
                 .collect();
-            Some(JsonRpcResponse::ok(req.id.clone(), serde_json::json!({"tools": tools})))
+            Some(JsonRpcResponse::ok(
+                req.id.clone(),
+                serde_json::json!({"tools": tools}),
+            ))
         }
 
         "tools/call" => {
@@ -215,7 +224,11 @@ async fn handle_json_rpc(
                 .unwrap_or("");
 
             if tool_name.is_empty() {
-                return Some(JsonRpcResponse::err(req.id.clone(), -32602, "missing tool name"));
+                return Some(JsonRpcResponse::err(
+                    req.id.clone(),
+                    -32602,
+                    "missing tool name",
+                ));
             }
 
             let arguments = params
@@ -227,7 +240,9 @@ async fn handle_json_rpc(
             // File tools do blocking I/O (directory cloning, walkdir, blake3 hashing,
             // subprocess execution) so they MUST run off the tokio worker threads.
             if super::file_tools::is_file_tool(tool_name) {
-                if let (Some(ref sched), Some(ref ws)) = (&config.auto_snapshots, &config.workspace_dir) {
+                if let (Some(ref sched), Some(ref ws)) =
+                    (&config.auto_snapshots, &config.workspace_dir)
+                {
                     let decision = policy.evaluate("builtin", Some(tool_name));
                     match decision {
                         ToolDecision::Block => {
@@ -255,26 +270,47 @@ async fn handle_json_rpc(
                             let mut sched = sched.lock().await;
                             match tool_name.as_str() {
                                 "snapshots_changes" => {
-                                    super::file_tools::handle_list_changed_files(&arguments, &sched, &ws, req_id)
+                                    super::file_tools::handle_list_changed_files(
+                                        &arguments, &sched, &ws, req_id,
+                                    )
                                 }
-                                "snapshots_list" => {
-                                    super::file_tools::handle_list_snapshots(&arguments, &sched, &ws, req_id)
-                                }
-                                "snapshots_revert" => {
-                                    super::file_tools::handle_revert_file(&arguments, &sched, &ws, req_id, Some(&db))
-                                }
+                                "snapshots_list" => super::file_tools::handle_list_snapshots(
+                                    &arguments, &sched, &ws, req_id,
+                                ),
+                                "snapshots_revert" => super::file_tools::handle_revert_file(
+                                    &arguments,
+                                    &sched,
+                                    &ws,
+                                    req_id,
+                                    Some(&db),
+                                ),
                                 "snapshots_create" => {
-                                    let resp = super::file_tools::handle_snapshot(&arguments, &mut sched, req_id);
+                                    let resp = super::file_tools::handle_snapshot(
+                                        &arguments, &mut sched, req_id,
+                                    );
                                     // Log manual snapshot to session DB for the stats UI.
                                     if resp.error.is_none() {
-                                        if let Some(last_slot) = sched.list_snapshots().into_iter()
-                                            .filter(|s| s.origin == crate::auto_snapshot::SnapshotOrigin::Manual)
+                                        if let Some(last_slot) = sched
+                                            .list_snapshots()
+                                            .into_iter()
+                                            .filter(|s| {
+                                                s.origin
+                                                    == crate::auto_snapshot::SnapshotOrigin::Manual
+                                            })
                                             .max_by_key(|s| s.slot)
                                         {
-                                            let stop_id = db.reader().ok()
-                                                .and_then(|r| r.query_raw("SELECT COALESCE(MAX(id),0) FROM fs_events").ok())
+                                            let stop_id = db
+                                                .reader()
+                                                .ok()
+                                                .and_then(|r| {
+                                                    r.query_raw(
+                                                        "SELECT COALESCE(MAX(id),0) FROM fs_events",
+                                                    )
+                                                    .ok()
+                                                })
                                                 .and_then(|json| {
-                                                    let v: serde_json::Value = serde_json::from_str(&json).ok()?;
+                                                    let v: serde_json::Value =
+                                                        serde_json::from_str(&json).ok()?;
                                                     v["rows"].get(0)?.get(0)?.as_i64()
                                                 })
                                                 .unwrap_or(0);
@@ -295,20 +331,30 @@ async fn handle_json_rpc(
                                     }
                                     resp
                                 }
-                                "snapshots_delete" => {
-                                    super::file_tools::handle_delete_snapshot(&arguments, &sched, req_id)
-                                }
-                                "snapshots_history" => {
-                                    super::file_tools::handle_snapshots_history(&arguments, &sched, &ws, req_id)
-                                }
-                                "snapshots_compact" => {
-                                    super::file_tools::handle_snapshots_compact(&arguments, &mut sched, req_id)
-                                }
-                                _ => JsonRpcResponse::err(req_id, -32602, format!("unknown file tool: {tool_name}")),
+                                "snapshots_delete" => super::file_tools::handle_delete_snapshot(
+                                    &arguments, &sched, req_id,
+                                ),
+                                "snapshots_history" => super::file_tools::handle_snapshots_history(
+                                    &arguments, &sched, &ws, req_id,
+                                ),
+                                "snapshots_compact" => super::file_tools::handle_snapshots_compact(
+                                    &arguments, &mut sched, req_id,
+                                ),
+                                _ => JsonRpcResponse::err(
+                                    req_id,
+                                    -32602,
+                                    format!("unknown file tool: {tool_name}"),
+                                ),
                             }
                         })
-                    }).await.unwrap_or_else(|e| {
-                        JsonRpcResponse::err(req_id_fallback, -32603, format!("file tool task failed: {e}"))
+                    })
+                    .await
+                    .unwrap_or_else(|e| {
+                        JsonRpcResponse::err(
+                            req_id_fallback,
+                            -32603,
+                            format!("file tool task failed: {e}"),
+                        )
                     });
                     return Some(resp);
                 } else {
@@ -338,19 +384,43 @@ async fn handle_json_rpc(
                 }
 
                 let dp = config.domain_policy.read().unwrap().clone();
-                return Some(builtin_tools::call_builtin_tool(
-                    tool_name,
-                    &arguments,
-                    &config.http_client,
-                    &dp,
-                    req.id.clone(),
-                    &config.db,
-                ).await);
+                return Some(
+                    builtin_tools::call_builtin_tool(
+                        tool_name,
+                        &arguments,
+                        &config.http_client,
+                        &dp,
+                        req.id.clone(),
+                        &config.db,
+                    )
+                    .await,
+                );
+            }
+
+            // Route browser tools (if browser manager is available).
+            if browser_tools::is_browser_tool(tool_name) {
+                if let Some(ref browser_mgr) = config.browser_manager {
+                    return Some(
+                        browser_tools::call_browser_tool(
+                            tool_name,
+                            &arguments,
+                            browser_mgr,
+                            req.id.clone(),
+                            &config.db,
+                        )
+                        .await,
+                    );
+                } else {
+                    return Some(JsonRpcResponse::err(
+                        req.id.clone(),
+                        -32603,
+                        "browser tools unavailable (browser manager not initialized)",
+                    ));
+                }
             }
 
             // External server tools: parse namespace prefix.
-            let (server_name, _local_name) = parse_namespaced(tool_name)
-                .unwrap_or(("", tool_name));
+            let (server_name, _local_name) = parse_namespaced(tool_name).unwrap_or(("", tool_name));
 
             let decision = policy.evaluate(server_name, Some(tool_name));
             match decision {
@@ -372,9 +442,13 @@ async fn handle_json_rpc(
                 let mgr = config.server_manager.lock().await;
                 match mgr.lookup_tool_peer(tool_name) {
                     Ok(p) => p,
-                    Err(e) => return Some(JsonRpcResponse::err(
-                        req.id.clone(), -32603, format!("tool call failed: {e}"),
-                    )),
+                    Err(e) => {
+                        return Some(JsonRpcResponse::err(
+                            req.id.clone(),
+                            -32603,
+                            format!("tool call failed: {e}"),
+                        ))
+                    }
                 }
             };
 
@@ -389,12 +463,14 @@ async fn handle_json_rpc(
 
             match peer.call_tool(params).await {
                 Ok(result) => {
-                    let result_json = serde_json::to_value(&result)
-                        .unwrap_or(serde_json::json!({}));
+                    let result_json =
+                        serde_json::to_value(&result).unwrap_or(serde_json::json!({}));
                     Some(JsonRpcResponse::ok(req.id.clone(), result_json))
                 }
                 Err(e) => Some(JsonRpcResponse::err(
-                    req.id.clone(), -32603, format!("tool call failed: {e}"),
+                    req.id.clone(),
+                    -32603,
+                    format!("tool call failed: {e}"),
                 )),
             }
         }
@@ -413,7 +489,10 @@ async fn handle_json_rpc(
                     })
                 })
                 .collect();
-            Some(JsonRpcResponse::ok(req.id.clone(), serde_json::json!({"resources": resources})))
+            Some(JsonRpcResponse::ok(
+                req.id.clone(),
+                serde_json::json!({"resources": resources}),
+            ))
         }
 
         "resources/read" => {
@@ -425,28 +504,38 @@ async fn handle_json_rpc(
                 .unwrap_or("");
 
             if uri.is_empty() {
-                return Some(JsonRpcResponse::err(req.id.clone(), -32602, "missing resource URI"));
+                return Some(JsonRpcResponse::err(
+                    req.id.clone(),
+                    -32602,
+                    "missing resource URI",
+                ));
             }
 
             let (peer, original_uri) = {
                 let mgr = config.server_manager.lock().await;
                 match mgr.lookup_resource_peer(uri) {
                     Ok(p) => p,
-                    Err(e) => return Some(JsonRpcResponse::err(
-                        req.id.clone(), -32603, format!("resource read failed: {e}"),
-                    )),
+                    Err(e) => {
+                        return Some(JsonRpcResponse::err(
+                            req.id.clone(),
+                            -32603,
+                            format!("resource read failed: {e}"),
+                        ))
+                    }
                 }
             };
 
             let params = ReadResourceRequestParams::new(original_uri.clone());
             Some(match peer.read_resource(params).await {
                 Ok(result) => {
-                    let result_json = serde_json::to_value(&result)
-                        .unwrap_or(serde_json::json!({}));
+                    let result_json =
+                        serde_json::to_value(&result).unwrap_or(serde_json::json!({}));
                     JsonRpcResponse::ok(req.id.clone(), result_json)
                 }
                 Err(e) => JsonRpcResponse::err(
-                    req.id.clone(), -32603, format!("resource read failed: {e}"),
+                    req.id.clone(),
+                    -32603,
+                    format!("resource read failed: {e}"),
                 ),
             })
         }
@@ -464,7 +553,10 @@ async fn handle_json_rpc(
                     })
                 })
                 .collect();
-            Some(JsonRpcResponse::ok(req.id.clone(), serde_json::json!({"prompts": prompts})))
+            Some(JsonRpcResponse::ok(
+                req.id.clone(),
+                serde_json::json!({"prompts": prompts}),
+            ))
         }
 
         "prompts/get" => {
@@ -475,7 +567,11 @@ async fn handle_json_rpc(
                 .unwrap_or("");
 
             if prompt_name.is_empty() {
-                return Some(JsonRpcResponse::err(req.id.clone(), -32602, "missing prompt name"));
+                return Some(JsonRpcResponse::err(
+                    req.id.clone(),
+                    -32602,
+                    "missing prompt name",
+                ));
             }
 
             let arguments = params
@@ -487,9 +583,13 @@ async fn handle_json_rpc(
                 let mgr = config.server_manager.lock().await;
                 match mgr.lookup_prompt_peer(prompt_name) {
                     Ok(p) => p,
-                    Err(e) => return Some(JsonRpcResponse::err(
-                        req.id.clone(), -32603, format!("prompt get failed: {e}"),
-                    )),
+                    Err(e) => {
+                        return Some(JsonRpcResponse::err(
+                            req.id.clone(),
+                            -32603,
+                            format!("prompt get failed: {e}"),
+                        ))
+                    }
                 }
             };
 
@@ -502,17 +602,21 @@ async fn handle_json_rpc(
 
             Some(match peer.get_prompt(params).await {
                 Ok(result) => {
-                    let result_json = serde_json::to_value(&result)
-                        .unwrap_or(serde_json::json!({}));
+                    let result_json =
+                        serde_json::to_value(&result).unwrap_or(serde_json::json!({}));
                     JsonRpcResponse::ok(req.id.clone(), result_json)
                 }
-                Err(e) => JsonRpcResponse::err(
-                    req.id.clone(), -32603, format!("prompt get failed: {e}"),
-                ),
+                Err(e) => {
+                    JsonRpcResponse::err(req.id.clone(), -32603, format!("prompt get failed: {e}"))
+                }
             })
         }
 
-        _ => Some(JsonRpcResponse::err(req.id.clone(), -32601, format!("method not found: {}", req.method))),
+        _ => Some(JsonRpcResponse::err(
+            req.id.clone(),
+            -32601,
+            format!("method not found: {}", req.method),
+        )),
     }
 }
 
@@ -531,7 +635,10 @@ async fn log_mcp_call(
         .and_then(|n| n.as_str());
 
     let server_name = match tool_name {
-        Some(t) if builtin_tools::is_builtin_tool(t) || super::file_tools::is_file_tool(t) => "builtin",
+        Some(t) if builtin_tools::is_builtin_tool(t) || super::file_tools::is_file_tool(t) => {
+            "builtin"
+        }
+        Some(t) if browser_tools::is_browser_tool(t) => "browser",
         Some(t) => parse_namespaced(t).map(|(s, _)| s).unwrap_or("gateway"),
         None => "gateway",
     };
@@ -582,7 +689,11 @@ async fn log_mcp_call(
         server_name: server_name.to_string(),
         method: req.method.clone(),
         tool_name: tool_name.map(String::from),
-        request_id: req.id.as_ref().and_then(|v| v.as_u64()).map(|n| n.to_string()),
+        request_id: req
+            .id
+            .as_ref()
+            .and_then(|v| v.as_u64())
+            .map(|n| n.to_string()),
         request_preview: req_preview,
         response_preview: resp_preview,
         decision: decision.to_string(),
@@ -609,12 +720,13 @@ mod tests {
         });
         McpGatewayConfig {
             server_manager: Mutex::new(McpServerManager::new(vec![], reqwest::Client::new())),
-            db,
+            db: Arc::clone(&db),
             policy: RwLock::new(Arc::new(McpPolicy::new())),
             domain_policy: std::sync::RwLock::new(Arc::new(DomainPolicy::default_dev())),
             http_client: reqwest::Client::new(),
             auto_snapshots: None,
             workspace_dir: None,
+            browser_manager: None,
         }
     }
 
@@ -668,7 +780,10 @@ mod tests {
         let config = test_config(&rt);
         let policy = McpPolicy::new();
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
-        assert!(resp.is_none(), "notifications should not produce a response");
+        assert!(
+            resp.is_none(),
+            "notifications should not produce a response"
+        );
     }
 
     #[test]
@@ -718,7 +833,12 @@ mod tests {
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
         assert!(resp.error.is_some());
-        assert!(resp.error.as_ref().unwrap().message.contains("blocked by policy"));
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("blocked by policy"));
     }
 
     #[test]
@@ -742,7 +862,10 @@ mod tests {
         assert!(resp.error.is_none()); // tool errors use isError in result
         let result = resp.result.unwrap();
         assert_eq!(result["isError"], true);
-        assert!(result["content"][0]["text"].as_str().unwrap().contains("blocked"));
+        assert!(result["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("blocked"));
     }
 
     #[test]
@@ -782,12 +905,32 @@ mod tests {
                 panic!("tool '{}' missing annotations", tool["name"]);
             });
             let obj = ann.as_object().unwrap();
-            assert!(obj.contains_key("readOnlyHint"), "missing readOnlyHint in {}", tool["name"]);
-            assert!(obj.contains_key("destructiveHint"), "missing destructiveHint in {}", tool["name"]);
-            assert!(obj.contains_key("idempotentHint"), "missing idempotentHint in {}", tool["name"]);
-            assert!(obj.contains_key("openWorldHint"), "missing openWorldHint in {}", tool["name"]);
+            assert!(
+                obj.contains_key("readOnlyHint"),
+                "missing readOnlyHint in {}",
+                tool["name"]
+            );
+            assert!(
+                obj.contains_key("destructiveHint"),
+                "missing destructiveHint in {}",
+                tool["name"]
+            );
+            assert!(
+                obj.contains_key("idempotentHint"),
+                "missing idempotentHint in {}",
+                tool["name"]
+            );
+            assert!(
+                obj.contains_key("openWorldHint"),
+                "missing openWorldHint in {}",
+                tool["name"]
+            );
             // Must NOT have snake_case keys (wire format violation)
-            assert!(!obj.contains_key("read_only_hint"), "snake_case key in wire format: {}", tool["name"]);
+            assert!(
+                !obj.contains_key("read_only_hint"),
+                "snake_case key in wire format: {}",
+                tool["name"]
+            );
         }
     }
 
@@ -809,10 +952,26 @@ mod tests {
         // All 3 builtins are read-only, non-destructive, idempotent, open-world
         for tool in &tools {
             let ann = tool.get("annotations").unwrap();
-            assert_eq!(ann["readOnlyHint"], true, "{} should be read-only", tool["name"]);
-            assert_eq!(ann["destructiveHint"], false, "{} should not be destructive", tool["name"]);
-            assert_eq!(ann["idempotentHint"], true, "{} should be idempotent", tool["name"]);
-            assert_eq!(ann["openWorldHint"], true, "{} should be open-world", tool["name"]);
+            assert_eq!(
+                ann["readOnlyHint"], true,
+                "{} should be read-only",
+                tool["name"]
+            );
+            assert_eq!(
+                ann["destructiveHint"], false,
+                "{} should not be destructive",
+                tool["name"]
+            );
+            assert_eq!(
+                ann["idempotentHint"], true,
+                "{} should be idempotent",
+                tool["name"]
+            );
+            assert_eq!(
+                ann["openWorldHint"], true,
+                "{} should be open-world",
+                tool["name"]
+            );
         }
     }
 
@@ -842,7 +1001,12 @@ mod tests {
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
         assert!(resp.error.is_some());
-        assert!(resp.error.as_ref().unwrap().message.contains("missing tool name"));
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("missing tool name"));
     }
 
     #[test]
@@ -860,7 +1024,12 @@ mod tests {
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
         assert!(resp.error.is_some());
-        assert!(resp.error.as_ref().unwrap().message.contains("missing tool name"));
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("missing tool name"));
     }
 
     #[test]
@@ -878,7 +1047,12 @@ mod tests {
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
         assert!(resp.error.is_some());
-        assert!(resp.error.as_ref().unwrap().message.contains("missing tool name"));
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("missing tool name"));
     }
 
     #[test]
@@ -924,7 +1098,10 @@ mod tests {
         let resp = resp.unwrap();
         // Should fail -- "fake" server doesn't exist, so it's an error,
         // NOT routed to the builtin handler.
-        assert!(resp.error.is_some(), "fake__fetch_http must not route to builtin");
+        assert!(
+            resp.error.is_some(),
+            "fake__fetch_http must not route to builtin"
+        );
     }
 
     #[test]
@@ -950,7 +1127,12 @@ mod tests {
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
         assert!(resp.error.is_some());
-        assert!(resp.error.as_ref().unwrap().message.contains("blocked by policy"));
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("blocked by policy"));
     }
 
     #[test]
@@ -975,7 +1157,12 @@ mod tests {
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
         assert!(resp.error.is_some());
-        assert!(resp.error.as_ref().unwrap().message.contains("blocked by policy"));
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("blocked by policy"));
     }
 
     #[test]
@@ -993,7 +1180,10 @@ mod tests {
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
         assert!(resp.error.is_none());
-        let resources = resp.result.unwrap()["resources"].as_array().unwrap().clone();
+        let resources = resp.result.unwrap()["resources"]
+            .as_array()
+            .unwrap()
+            .clone();
         assert!(resources.is_empty());
     }
 
@@ -1012,7 +1202,12 @@ mod tests {
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
         assert!(resp.error.is_some());
-        assert!(resp.error.as_ref().unwrap().message.contains("missing resource URI"));
+        assert!(resp
+            .error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("missing resource URI"));
     }
 
     #[test]
@@ -1055,7 +1250,10 @@ mod tests {
         let tools = resp.result.unwrap()["tools"].as_array().unwrap().clone();
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         for file_tool in super::super::file_tools::FILE_TOOL_NAMES {
-            assert!(!names.contains(file_tool), "file tool {file_tool} should not appear without VirtioFS");
+            assert!(
+                !names.contains(file_tool),
+                "file tool {file_tool} should not appear without VirtioFS"
+            );
         }
     }
 
@@ -1091,7 +1289,10 @@ mod tests {
         assert_eq!(tools.len(), 10);
         let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
         for file_tool in super::super::file_tools::FILE_TOOL_NAMES {
-            assert!(names.contains(file_tool), "file tool {file_tool} missing from tools/list");
+            assert!(
+                names.contains(file_tool),
+                "file tool {file_tool} missing from tools/list"
+            );
         }
     }
 
@@ -1138,7 +1339,11 @@ mod tests {
         let policy = McpPolicy::new();
         let resp = rt.block_on(handle_json_rpc(&req, &config, &policy, "test"));
         let resp = resp.unwrap();
-        assert!(resp.error.is_none(), "snapshot should succeed: {:?}", resp.error);
+        assert!(
+            resp.error.is_none(),
+            "snapshot should succeed: {:?}",
+            resp.error
+        );
     }
 
     #[test]
@@ -1167,7 +1372,9 @@ mod tests {
     }
 
     /// Test config with auto-snapshots enabled (VirtioFS mode).
-    fn test_config_with_snapshots(rt: &tokio::runtime::Runtime) -> (McpGatewayConfig, tempfile::TempDir) {
+    fn test_config_with_snapshots(
+        rt: &tokio::runtime::Runtime,
+    ) -> (McpGatewayConfig, tempfile::TempDir) {
         use crate::auto_snapshot::AutoSnapshotScheduler;
 
         let dir = tempfile::tempdir().unwrap();
@@ -1179,9 +1386,8 @@ mod tests {
         // Write a file so snapshots have content.
         std::fs::write(session.join("workspace/test.txt"), "hello").unwrap();
 
-        let scheduler = AutoSnapshotScheduler::new(
-            session.clone(), 3, 4, std::time::Duration::from_secs(300),
-        );
+        let scheduler =
+            AutoSnapshotScheduler::new(session.clone(), 3, 4, std::time::Duration::from_secs(300));
 
         let db = rt.block_on(async {
             let path = session.join("test.db");
@@ -1196,6 +1402,7 @@ mod tests {
             http_client: reqwest::Client::new(),
             auto_snapshots: Some(Arc::new(tokio::sync::Mutex::new(scheduler))),
             workspace_dir: Some(session.join("workspace")),
+            browser_manager: None,
         };
         (config, dir)
     }
@@ -1225,12 +1432,18 @@ mod tests {
             tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 handle_json_rpc(&req, &config, &policy, "test"),
-            ).await
+            )
+            .await
         });
 
-        let resp = resp.expect("snapshot_create timed out -- possible deadlock")
+        let resp = resp
+            .expect("snapshot_create timed out -- possible deadlock")
             .expect("should return Some for tools/call");
-        assert!(resp.error.is_none(), "snapshot_create should succeed: {:?}", resp.error);
+        assert!(
+            resp.error.is_none(),
+            "snapshot_create should succeed: {:?}",
+            resp.error
+        );
 
         let result = resp.result.unwrap();
         let text = result["content"][0]["text"].as_str().unwrap();
@@ -1273,12 +1486,16 @@ mod tests {
             tokio::time::timeout(
                 std::time::Duration::from_secs(5),
                 handle_json_rpc(&list_req, &config, &policy, "test"),
-            ).await
+            )
+            .await
         });
         let resp = resp.expect("snapshots_list timed out").unwrap();
         assert!(resp.error.is_none());
 
-        let text = resp.result.unwrap()["content"][0]["text"].as_str().unwrap().to_string();
+        let text = resp.result.unwrap()["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_string();
         let data: serde_json::Value = serde_json::from_str(&text)
             .expect("snapshots_list must return valid JSON when format=json");
         assert!(data["snapshots"].as_array().unwrap().len() >= 1);

--- a/crates/capsem-core/src/mcp/mod.rs
+++ b/crates/capsem-core/src/mcp/mod.rs
@@ -1,3 +1,4 @@
+pub mod browser_tools;
 pub mod builtin_tools;
 pub mod file_tools;
 pub mod gateway;
@@ -183,10 +184,7 @@ pub fn compute_tool_hash(tool: &McpToolDef) -> String {
 }
 
 /// Detect changes between newly discovered tools and the cache.
-pub fn detect_pin_changes(
-    new_tools: &[McpToolDef],
-    cache: &[ToolCacheEntry],
-) -> Vec<PinChange> {
+pub fn detect_pin_changes(new_tools: &[McpToolDef], cache: &[ToolCacheEntry]) -> Vec<PinChange> {
     let mut changes = Vec::new();
     let cache_map: HashMap<&str, &ToolCacheEntry> = cache
         .iter()
@@ -241,7 +239,12 @@ pub fn detect_name_collisions(tools: &[McpToolDef]) -> Vec<(String, Vec<String>)
     by_name
         .into_iter()
         .filter(|(_, servers)| servers.len() > 1)
-        .map(|(name, servers)| (name.to_string(), servers.into_iter().map(String::from).collect()))
+        .map(|(name, servers)| {
+            (
+                name.to_string(),
+                servers.into_iter().map(String::from).collect(),
+            )
+        })
         .collect()
 }
 
@@ -254,13 +257,10 @@ fn tool_cache_path() -> Option<std::path::PathBuf> {
 pub fn save_tool_cache(entries: &[ToolCacheEntry]) -> Result<(), String> {
     let path = tool_cache_path().ok_or("HOME not set")?;
     if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("create dir: {e}"))?;
+        std::fs::create_dir_all(parent).map_err(|e| format!("create dir: {e}"))?;
     }
-    let json = serde_json::to_string_pretty(entries)
-        .map_err(|e| format!("serialize: {e}"))?;
-    std::fs::write(&path, json)
-        .map_err(|e| format!("write: {e}"))
+    let json = serde_json::to_string_pretty(entries).map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(&path, json).map_err(|e| format!("write: {e}"))
 }
 
 /// Load tool cache from disk. Returns empty vec if file missing.
@@ -279,7 +279,10 @@ pub fn load_tool_cache() -> Vec<ToolCacheEntry> {
 }
 
 /// Build cache entries from current tool catalog.
-pub fn build_cache_entries(tools: &[McpToolDef], existing: &[ToolCacheEntry]) -> Vec<ToolCacheEntry> {
+pub fn build_cache_entries(
+    tools: &[McpToolDef],
+    existing: &[ToolCacheEntry],
+) -> Vec<ToolCacheEntry> {
     let now = humantime::format_rfc3339(std::time::SystemTime::now()).to_string();
     let existing_map: HashMap<&str, &ToolCacheEntry> = existing
         .iter()
@@ -298,12 +301,20 @@ pub fn build_cache_entries(tools: &[McpToolDef], existing: &[ToolCacheEntry]) ->
                 server_name: tool.server_name.clone(),
                 annotations: tool.annotations.clone(),
                 pin_hash: hash.clone(),
-                first_seen: prev.map(|p| p.first_seen.clone()).unwrap_or_else(|| now.clone()),
+                first_seen: prev
+                    .map(|p| p.first_seen.clone())
+                    .unwrap_or_else(|| now.clone()),
                 last_seen: now.clone(),
-                approved: prev.map(|p| {
-                    // Stay approved only if hash hasn't changed
-                    if p.pin_hash == hash { p.approved } else { false }
-                }).unwrap_or(false),
+                approved: prev
+                    .map(|p| {
+                        // Stay approved only if hash hasn't changed
+                        if p.pin_hash == hash {
+                            p.approved
+                        } else {
+                            false
+                        }
+                    })
+                    .unwrap_or(false),
             }
         })
         .collect()
@@ -382,7 +393,10 @@ fn parse_mcp_servers_from_file(path: &Path, source: &str) -> Option<Vec<McpServe
                 format!("{} {}", command, args.join(" "))
             };
 
-            debug!(name, source, command, "detected stdio MCP server (unsupported)");
+            debug!(
+                name,
+                source, command, "detected stdio MCP server (unsupported)"
+            );
             defs.push(McpServerDef {
                 name: name.clone(),
                 url: display_command,
@@ -401,8 +415,8 @@ fn parse_mcp_servers_from_file(path: &Path, source: &str) -> Option<Vec<McpServe
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
     use crate::mcp::policy::{McpManualServer, McpUserConfig};
+    use std::io::Write;
 
     fn make_tool(ns_name: &str, orig_name: &str, server: &str, desc: Option<&str>) -> McpToolDef {
         McpToolDef {
@@ -438,7 +452,8 @@ mod tests {
     fn compute_tool_hash_changes_on_schema() {
         let mut tool = make_tool("github__search", "search", "github", Some("Search"));
         let h1 = compute_tool_hash(&tool);
-        tool.input_schema = serde_json::json!({"type": "object", "properties": {"q": {"type": "string"}}});
+        tool.input_schema =
+            serde_json::json!({"type": "object", "properties": {"q": {"type": "string"}}});
         let h2 = compute_tool_hash(&tool);
         assert_ne!(h1, h2);
     }
@@ -446,9 +461,15 @@ mod tests {
     #[test]
     fn compute_tool_hash_changes_on_annotations() {
         let mut tool = make_tool("github__search", "search", "github", Some("Search"));
-        tool.annotations = Some(ToolAnnotations { read_only_hint: true, ..Default::default() });
+        tool.annotations = Some(ToolAnnotations {
+            read_only_hint: true,
+            ..Default::default()
+        });
         let h1 = compute_tool_hash(&tool);
-        tool.annotations = Some(ToolAnnotations { read_only_hint: false, ..Default::default() });
+        tool.annotations = Some(ToolAnnotations {
+            read_only_hint: false,
+            ..Default::default()
+        });
         let h2 = compute_tool_hash(&tool);
         assert_ne!(h1, h2);
     }
@@ -476,7 +497,12 @@ mod tests {
 
     #[test]
     fn detect_pin_changes_description_changed() {
-        let tool = make_tool("github__search", "search", "github", Some("New description"));
+        let tool = make_tool(
+            "github__search",
+            "search",
+            "github",
+            Some("New description"),
+        );
         let cache = vec![ToolCacheEntry {
             namespaced_name: "github__search".into(),
             original_name: "search".into(),
@@ -529,7 +555,12 @@ mod tests {
             description: Some("Search repos".into()),
             server_name: "github".into(),
             annotations: None,
-            pin_hash: compute_tool_hash(&make_tool("github__search", "search", "github", Some("Search repos"))),
+            pin_hash: compute_tool_hash(&make_tool(
+                "github__search",
+                "search",
+                "github",
+                Some("Search repos"),
+            )),
             first_seen: "2025-01-01".into(),
             last_seen: "2025-01-01".into(),
             approved: true,
@@ -563,15 +594,24 @@ mod tests {
     #[test]
     fn rug_pull_annotation_flip() {
         let mut tool = make_tool("github__delete", "delete", "github", Some("Delete"));
-        tool.annotations = Some(ToolAnnotations { read_only_hint: false, ..Default::default() });
+        tool.annotations = Some(ToolAnnotations {
+            read_only_hint: false,
+            ..Default::default()
+        });
         let mut original = make_tool("github__delete", "delete", "github", Some("Delete"));
-        original.annotations = Some(ToolAnnotations { read_only_hint: true, ..Default::default() });
+        original.annotations = Some(ToolAnnotations {
+            read_only_hint: true,
+            ..Default::default()
+        });
         let cache = vec![ToolCacheEntry {
             namespaced_name: "github__delete".into(),
             original_name: "delete".into(),
             description: Some("Delete".into()),
             server_name: "github".into(),
-            annotations: Some(ToolAnnotations { read_only_hint: true, ..Default::default() }),
+            annotations: Some(ToolAnnotations {
+                read_only_hint: true,
+                ..Default::default()
+            }),
             pin_hash: compute_tool_hash(&original),
             first_seen: "2025-01-01".into(),
             last_seen: "2025-01-01".into(),
@@ -647,7 +687,9 @@ mod tests {
         };
         let corp = McpUserConfig::default();
         let list = build_server_list(&user, &corp);
-        assert!(list.iter().any(|s| s.name == "myserver" && s.source == "manual"));
+        assert!(list
+            .iter()
+            .any(|s| s.name == "myserver" && s.source == "manual"));
     }
 
     #[test]
@@ -664,7 +706,9 @@ mod tests {
             ..Default::default()
         };
         let list = build_server_list(&user, &corp);
-        assert!(list.iter().any(|s| s.name == "corp-server" && s.source == "corp"));
+        assert!(list
+            .iter()
+            .any(|s| s.name == "corp-server" && s.source == "corp"));
     }
 
     #[test]
@@ -814,11 +858,7 @@ mod tests {
     fn parse_server_without_url_or_command_skipped() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("settings.json");
-        std::fs::write(
-            &path,
-            r#"{"mcpServers": {"bad": {"name": "bad"}}}"#,
-        )
-        .unwrap();
+        std::fs::write(&path, r#"{"mcpServers": {"bad": {"name": "bad"}}}"#).unwrap();
         let defs = parse_mcp_servers_from_file(&path, "test").unwrap();
         assert_eq!(defs.len(), 0);
     }
@@ -862,10 +902,9 @@ mod tests {
         let bins = parse_cargo_bin_names(&root.join("crates/capsem-agent/Cargo.toml"));
         assert!(!bins.is_empty(), "no [[bin]] entries found in capsem-agent");
 
-        let template = std::fs::read_to_string(
-            root.join("src/capsem/builder/templates/Dockerfile.rootfs.j2"),
-        )
-        .expect("cannot read Dockerfile.rootfs.j2");
+        let template =
+            std::fs::read_to_string(root.join("src/capsem/builder/templates/Dockerfile.rootfs.j2"))
+                .expect("cannot read Dockerfile.rootfs.j2");
 
         // The Jinja template uses a loop over guest_binaries to COPY each binary.
         // Verify the loop pattern exists -- the Python build context test
@@ -897,8 +936,8 @@ mod tests {
         let bins = parse_cargo_bin_names(&root.join("crates/capsem-agent/Cargo.toml"));
         assert!(!bins.is_empty(), "no [[bin]] entries found in capsem-agent");
 
-        let justfile = std::fs::read_to_string(root.join("justfile"))
-            .expect("cannot read justfile");
+        let justfile =
+            std::fs::read_to_string(root.join("justfile")).expect("cannot read justfile");
 
         // Extract the _pack-initrd recipe section (from "_pack-initrd:" to next recipe)
         let start = justfile

--- a/crates/capsem-core/src/mcp/playwright_server.js
+++ b/crates/capsem-core/src/mcp/playwright_server.js
@@ -1,0 +1,159 @@
+const http = require('http');
+const { chromium } = require('playwright');
+
+let browser = null;
+let page = null;
+
+async function initBrowser() {
+  if (!browser) {
+    browser = await chromium.launch({ headless: true });
+    page = await browser.newPage();
+  }
+}
+
+async function handleAction(action, params) {
+  await initBrowser();
+
+  switch (action) {
+    case 'navigate': {
+      const { url, timeout = 30000, waitUntil = 'load' } = params;
+      const response = await page.goto(url, { timeout, waitUntil });
+      return {
+        url: response.url(),
+        title: await page.title(),
+        status: response.status(),
+      };
+    }
+
+    case 'click': {
+      const { selector, timeout = 5000 } = params;
+      await page.waitForSelector(selector, { timeout });
+      await page.click(selector);
+      return { clicked: selector };
+    }
+
+    case 'type': {
+      const { selector, text, clearFirst = true } = params;
+      if (clearFirst) {
+        await page.fill(selector, '');
+      }
+      await page.type(selector, text);
+      return { typed: text, into: selector };
+    }
+
+    case 'screenshot': {
+      const { selector, fullPage = false, maxWidth = 1280 } = params;
+      let screenshot;
+      if (selector) {
+        const element = await page.$(selector);
+        if (!element) throw new Error(`Element not found: ${selector}`);
+        screenshot = await element.screenshot({ type: 'png' });
+      } else {
+        screenshot = await page.screenshot({ fullPage, type: 'png' });
+      }
+      return {
+        image: screenshot.toString('base64'),
+        width: maxWidth,
+        format: 'png',
+      };
+    }
+
+    case 'evaluate': {
+      const { javascript, timeout = 10000 } = params;
+      const result = await page.evaluate(javascript);
+      return { result };
+    }
+
+    case 'getText': {
+      const { selector, maxLength = 5000 } = params;
+      const elements = await page.$$(selector);
+      const texts = await Promise.all(
+        elements.map(async (el) => {
+          const text = await el.textContent();
+          return text || '';
+        })
+      );
+      const combined = texts.filter(t => t).join('\n\n');
+      return {
+        text: combined.substring(0, maxLength),
+        length: combined.length,
+        elementsFound: elements.length,
+      };
+    }
+
+    case 'fillForm': {
+      const { fields } = params;
+      const results = [];
+      for (const field of fields) {
+        await page.fill(field.selector, field.value);
+        results.push({ selector: field.selector, value: field.value });
+      }
+      return { filled: results };
+    }
+
+    case 'getContent': {
+      const { selector, format = 'text', maxLength = 5000 } = params;
+      let content;
+      if (selector) {
+        const element = await page.$(selector);
+        if (!element) throw new Error(`Element not found: ${selector}`);
+        if (format === 'html') {
+          content = await element.innerHTML();
+        } else {
+          content = await element.innerText();
+        }
+      } else {
+        if (format === 'html') {
+          content = await page.content();
+        } else {
+          content = await page.innerText('body');
+        }
+      }
+      return {
+        content: content.substring(0, maxLength),
+        length: content.length,
+        format,
+      };
+    }
+
+    case 'close': {
+      if (browser) {
+        await browser.close();
+        browser = null;
+        page = null;
+      }
+      return { closed: true };
+    }
+
+    default:
+      throw new Error(`Unknown action: ${action}`);
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/execute') {
+    let body = '';
+    req.on('data', chunk => { body += chunk.toString(); });
+    req.on('end', async () => {
+      try {
+        const { action, params } = JSON.parse(body);
+        const result = await handleAction(action, params);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ result }));
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: error.message }));
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = 0; // Let OS assign a random available port
+server.listen(PORT, '127.0.0.1', () => {
+  const address = server.address();
+  // Output the endpoint URL for the Rust side to parse
+  console.log(`ws://127.0.0.1:${address.port}`);
+});

--- a/skills/dev-browser/SKILL.md
+++ b/skills/dev-browser/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: dev-browser
+description: Headless browser MCP tools. Covers the 9 browser tools (navigate, click, type, screenshot, etc), Playwright integration, and browser session management.
+---
+
+# Browser MCP Tools
+
+AI agents in the guest VM can control a headless Chromium browser through MCP tools. The browser runs on the host, not in the VM.
+
+## Architecture
+
+```
+Guest (Claude/Gemini) -> capsem-mcp-server -> vsock:5003 -> MCP Gateway
+  -> BrowserManager -> PlaywrightServer (Node.js subprocess)
+  -> Headless Chromium
+  -> Telemetry -> session.db mcp_calls table
+```
+
+The Playwright server is a Node.js process that starts on first browser tool call. It outputs a ws:// endpoint on stdout that the Rust side parses to get the HTTP endpoint. Communication is via HTTP POST to `/execute`.
+
+## Tools
+
+| Tool | What it does |
+|------|-------------|
+| `browser_navigate` | Navigate to URL, returns title + final URL + status |
+| `browser_click` | Click element by CSS selector |
+| `browser_type` | Type text into input field |
+| `browser_screenshot` | Capture screenshot as base64 PNG |
+| `browser_evaluate` | Run JavaScript in page context |
+| `browser_get_text` | Extract text from elements |
+| `browser_fill_form` | Fill multiple form fields at once |
+| `browser_get_content` | Get page HTML or text |
+| `browser_close` | Close browser session |
+
+All tools are namespaced under `browser` in telemetry. They show up in `tools/list` automatically when browser_manager is initialized.
+
+## Usage
+
+AI agent calls them like any other MCP tool:
+
+```json
+{"method": "tools/call", "params": {"name": "browser_navigate", "arguments": {"url": "https://example.com/login"}}}
+{"method": "tools/call", "params": {"name": "browser_fill_form", "arguments": {"fields": [{"selector": "#user", "value": "admin"}, {"selector": "#pass", "value": "secret"}]}}}
+{"method": "tools/call", "params": {"name": "browser_click", "arguments": {"selector": "button[type='submit']"}}}
+{"method": "tools/call", "params": {"name": "browser_screenshot", "arguments": {}}}
+```
+
+## Setup
+
+Browser tools need Node.js and Playwright on the host:
+
+```bash
+npx playwright install
+```
+
+If Playwright isn't installed, the first browser tool call will fail with a clear error message telling the user to run the install command.
+
+## Key files
+
+| File | What's in it |
+|------|-------------|
+| `crates/capsem-core/src/mcp/browser_tools.rs` | Tool defs, handlers, BrowserManager, PlaywrightServer |
+| `crates/capsem-core/src/mcp/playwright_server.js` | Node.js server that wraps Playwright |
+| `crates/capsem-core/src/mcp/gateway.rs` | Browser tool routing in tools/call |
+| `skills/dev-browser/references/browser-wire.md` | Full wire format and schema reference |
+
+## Testing
+
+```bash
+cargo test -p capsem-core mcp::browser_tools
+```
+
+For integration testing, boot a VM and have an AI agent call the browser tools. Check session.db afterward with `just inspect-session`.
+
+## Notes
+
+- Browser is lazily initialized (starts on first tool call)
+- Session is stateful across tool calls (cookies, localStorage persist)
+- Browser binds to 127.0.0.1 only
+- All calls logged to mcp_calls table with server_name="browser"
+- Temp JS file is written to temp dir with UUID name, cleaned up after 60s

--- a/skills/dev-browser/references/browser-wire.md
+++ b/skills/dev-browser/references/browser-wire.md
@@ -1,0 +1,163 @@
+# Browser Tools Reference
+
+## PlaywrightServer
+
+The Node.js server is embedded in `playwright_server.js`. On startup:
+
+1. Rust writes it to a temp file with UUID name
+2. Node.js process starts: `node <temp_file>`
+3. Server listens on random port on 127.0.0.1
+4. Server prints `ws://127.0.0.1:<port>` to stdout
+5. Rust parses the URL and converts ws:// to http:// for requests
+
+The HTTP API is a single POST endpoint at `/execute`:
+
+```json
+// Request
+{"action": "navigate", "params": {"url": "https://example.com"}}
+
+// Response (success)
+{"result": {"url": "https://example.com", "title": "Example", "status": 200}}
+
+// Response (error)
+{"error": "Navigation timeout of 30000ms exceeded"}
+```
+
+## Tool Schemas
+
+### browser_navigate
+
+```json
+{
+  "url": "string (required) - must include http:// or https://",
+  "timeout": "integer (optional, default 30000)",
+  "wait_until": "string (optional, default 'load') - 'load' | 'domcontentloaded' | 'networkidle'"
+}
+```
+
+Returns: URL, final URL (after redirects), page title, HTTP status.
+
+### browser_click
+
+```json
+{
+  "selector": "string (required) - CSS selector",
+  "timeout": "integer (optional, default 5000)"
+}
+```
+
+### browser_type
+
+```json
+{
+  "selector": "string (required) - CSS selector for input",
+  "text": "string (required)",
+  "clear_first": "boolean (optional, default true)"
+}
+```
+
+Special keys: `{Enter}`, `{Tab}`, `{Backspace}`, `{ArrowLeft}`, etc.
+
+### browser_screenshot
+
+```json
+{
+  "selector": "string (optional) - crop to element",
+  "full_page": "boolean (optional, default false)",
+  "max_width": "integer (optional, default 1280)"
+}
+```
+
+Returns base64 PNG with dimensions. The response format is:
+
+```
+Screenshot captured
+Width: 1280 px
+Format: png
+Size: 234567 bytes
+
+data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...
+```
+
+### browser_evaluate
+
+```json
+{
+  "javascript": "string (required) - JS code to run in page context",
+  "timeout": "integer (optional, default 10000)"
+}
+```
+
+Can access document, window, DOM APIs. Result is serialized to JSON.
+
+### browser_get_text
+
+```json
+{
+  "selector": "string (required) - CSS selector",
+  "max_length": "integer (optional, default 5000)"
+}
+```
+
+Returns text from all matching elements, joined with double newlines. Truncates if longer than max_length.
+
+### browser_fill_form
+
+```json
+{
+  "fields": "array (required) - [{selector, value}, ...]"
+}
+```
+
+Each field needs both selector and value. Fails on first error.
+
+### browser_get_content
+
+```json
+{
+  "selector": "string (optional) - CSS selector, defaults to full page",
+  "format": "string (optional, default 'text') - 'html' | 'text'",
+  "max_length": "integer (optional, default 5000)"
+}
+```
+
+### browser_close
+
+No parameters. Safe to call even if browser isn't initialized.
+
+## Telemetry
+
+All calls go to `mcp_calls` table:
+
+| Column | Value |
+|--------|-------|
+| server_name | "browser" |
+| method | "tools/call" |
+| tool_name | "browser_navigate", etc |
+| decision | "allowed" or "error" |
+| process_name | "browser" |
+| bytes_sent | request JSON size |
+| bytes_received | response JSON size |
+
+Request/response previews are capped at 256KB by the logger.
+
+## Error Codes
+
+| Code | When |
+|------|------|
+| -32602 | Missing required parameter |
+| -32603 | Playwright execution failure |
+
+## Common Issues
+
+**"browser tools unavailable"** - browser_manager wasn't passed to gateway config. Check that the VM boot code initializes it.
+
+**"Failed to start Playwright server"** - Node.js or Playwright not installed. Run `npx playwright install`.
+
+**"Navigation timeout"** - Page didn't load in time. Increase timeout parameter or check if the URL is reachable.
+
+**"Element not found"** - CSS selector doesn't match anything. Could be timing issue (page hasn't fully loaded) or wrong selector.
+
+## Temp File Handling
+
+The JS script is written to `<temp_dir>/capsem_playwright_<uuid>.js`. A background tokio task cleans it up after 60s. The file is also removed on startup failure or when the PlaywrightServer drops.

--- a/skills/dev-mcp/SKILL.md
+++ b/skills/dev-mcp/SKILL.md
@@ -12,7 +12,7 @@ The MCP gateway bridges AI agents in the guest VM to external MCP servers on the
 ```
 Guest (Claude/Gemini) -> capsem-mcp-server (stdin/stdout relay)
   -> vsock:5003 -> MCP Gateway (capsem-core)
-  -> Policy check -> Route to: builtin tools | external MCP servers (via rmcp)
+  -> Policy check -> Route to: builtin tools | browser tools | external MCP servers (via rmcp)
   -> Telemetry -> session.db mcp_calls table
 ```
 
@@ -82,6 +82,11 @@ Decisions: `Allow`, `Warn` (log + continue), `Block` (error -32600).
 
 All use namespace prefix `builtin` (e.g., `builtin__http_get`).
 
+### Browser tools (headless browser automation)
+`browser_navigate`, `browser_click`, `browser_type`, `browser_screenshot`, `browser_evaluate`, `browser_get_text`, `browser_fill_form`, `browser_get_content`, `browser_close`
+
+See `/dev-browser` skill for full browser tools documentation.
+
 ## Key source files
 
 | File | Purpose |
@@ -90,6 +95,8 @@ All use namespace prefix `builtin` (e.g., `builtin__http_get`).
 | `crates/capsem-core/src/mcp/types.rs` | JsonRpcRequest/Response, McpToolDef, annotations |
 | `crates/capsem-core/src/mcp/server_manager.rs` | rmcp client pool, tool routing, catalog |
 | `crates/capsem-core/src/mcp/policy.rs` | Tool/server allow/warn/block decisions |
+| `crates/capsem-core/src/mcp/browser_tools.rs` | Browser tool definitions, session manager, handlers |
+| `crates/capsem-core/src/mcp/builtin_tools.rs` | HTTP tool implementations |
 | `crates/capsem-core/src/mcp/mod.rs` | Tool cache, server detection, collision detection |
 | `crates/capsem-agent/src/main.rs` | capsem-mcp-server binary (stdin/stdout relay) |
 


### PR DESCRIPTION
Implements #14

Adds 9 browser tools (navigate, click, type, screenshot, evaluate, getText, fillForm, getContent, close) backed by Playwright running on the host. Browser starts lazily on first tool call, maintains stateful session across calls.

## Architecture

Node.js Playwright server runs on host, Rust wrapper manages process lifecycle via subprocess with HTTP API. All calls logged to session.db telemetry.

## Key files

- `crates/capsem-core/src/mcp/browser_tools.rs` (new, 1244 lines)
- `crates/capsem-core/src/mcp/playwright_server.js` (new, 160 lines)
- `skills/dev-browser/SKILL.md` (new documentation)
- `crates/capsem-core/src/mcp/gateway.rs` (updated for browser routing)

## Requirements

Node.js + Playwright on host:

```bash
npx playwright install
```

## Testing

```bash
cargo test -p capsem-core mcp::browser_tools
```