### PR TITLE
Harden CLI/API consistency and remove legacy file routes

### DIFF
--- a/crates/capsem-mcp/src/main.rs
+++ b/crates/capsem-mcp/src/main.rs
@@ -202,11 +202,6 @@ fn build_purge_body(params: &PurgeParams) -> Value {
     json!({ "all": params.all.unwrap_or(false) })
 }
 
-/// Body for POST /read_file/{id}.
-fn build_read_file_body(params: &FileReadParams) -> Value {
-    json!({ "path": params.path })
-}
-
 /// Resolve the UDS path following the env-var precedence used by main().
 fn resolve_uds_path(override_val: Option<&str>, run_dir: &std::path::Path) -> PathBuf {
     override_val
@@ -348,6 +343,63 @@ impl UdsClient {
             Ok(r) => Ok(r),
             Err(e) => {
                 error!(error = %e, body = %String::from_utf8_lossy(&body_bytes), "failed to parse service response");
+                Err(e.into())
+            }
+        }
+    }
+
+    async fn request_binary<R: for<'de> Deserialize<'de>>(
+        &self,
+        method: &str,
+        path: &str,
+        content_type: &str,
+        body: Vec<u8>,
+    ) -> Result<R> {
+        info!(method, path, content_type, "sending UDS binary request");
+
+        let stream = match UnixStream::connect(&self.uds_path).await {
+            Ok(s) => s,
+            Err(_) => {
+                self.try_ensure_service().await?;
+                UnixStream::connect(&self.uds_path).await?
+            }
+        };
+
+        let io = TokioIo::new(stream);
+        let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+        tokio::task::spawn(async move {
+            if let Err(err) = conn.await {
+                error!("Connection failed: {:?}", err);
+            }
+        });
+
+        let req = Request::builder()
+            .method(method)
+            .uri(format!("http://localhost{}", path))
+            .header("Content-Type", content_type)
+            .body(Full::new(Bytes::from(body)))?;
+
+        let res = match sender.send_request(req).await {
+            Ok(r) => r,
+            Err(e) => {
+                error!(error = %e, "failed to send binary request to service");
+                return Err(e.into());
+            }
+        };
+        let status = res.status();
+        let body_bytes = res.collect().await?.to_bytes();
+        if !status.is_success() {
+            let msg = serde_json::from_slice::<Value>(&body_bytes)
+                .ok()
+                .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_string))
+                .unwrap_or_else(|| String::from_utf8_lossy(&body_bytes).into_owned());
+            error!(method, path, status = %status, body = %msg, "service returned non-success status");
+            return Err(anyhow::anyhow!("{status}: {msg}"));
+        }
+        match serde_json::from_slice(&body_bytes) {
+            Ok(r) => Ok(r),
+            Err(e) => {
+                error!(error = %e, body = %String::from_utf8_lossy(&body_bytes), "failed to parse binary response");
                 Err(e.into())
             }
         }
@@ -768,32 +820,39 @@ impl CapsemHandler {
 
     #[tool(
         name = "capsem_read_file",
-        description = "Read a file from a session's guest filesystem. Returns file content as text"
+        description = "Read a file from a session workspace path. Returns file content as text"
     )]
     async fn read_file(
         &self,
         Parameters(params): Parameters<FileReadParams>,
     ) -> Result<String, String> {
-        let body = build_read_file_body(&params);
-        let resp = self
-            .client
-            .request::<Value, Value>("POST", &format!("/read_file/{}", params.id), Some(body))
-            .await;
-        format_service_response(resp)
+        let q = query_string(&[("path", Some(params.path))]);
+        let path = format!("/files/{}/content{q}", params.id);
+        match self.client.request_text("GET", &path).await {
+            Ok(content) => Ok(serde_json::to_string_pretty(&json!({ "content": content }))
+                .unwrap_or_else(|_| "{\"content\":\"\"}".to_string())),
+            Err(e) => Err(e.to_string()),
+        }
     }
 
     #[tool(
         name = "capsem_write_file",
-        description = "Write a file to a session's guest filesystem"
+        description = "Write a file to a session workspace path"
     )]
     async fn write_file(
         &self,
         Parameters(params): Parameters<FileWriteParams>,
     ) -> Result<String, String> {
-        let path = format!("/write_file/{}", params.id);
+        let q = query_string(&[("path", Some(params.path.clone()))]);
+        let path = format!("/files/{}/content{q}", params.id);
         let resp = self
             .client
-            .request::<FileWriteParams, Value>("POST", &path, Some(params))
+            .request_binary::<Value>(
+                "POST",
+                &path,
+                "application/octet-stream",
+                params.content.into_bytes(),
+            )
             .await;
         format_service_response(resp)
     }

--- a/crates/capsem-mcp/src/tests.rs
+++ b/crates/capsem-mcp/src/tests.rs
@@ -846,7 +846,7 @@ fn fork_body_without_description() {
 }
 
 // -----------------------------------------------------------------------
-// build_persist_body / build_purge_body / build_read_file_body
+// build_persist_body / build_purge_body
 // -----------------------------------------------------------------------
 
 #[test]
@@ -873,17 +873,6 @@ fn purge_body_all_true_preserved() {
     let p = PurgeParams { all: Some(true) };
     let body = build_purge_body(&p);
     assert_eq!(body["all"], true);
-}
-
-#[test]
-fn read_file_body_contains_path_only() {
-    let p = FileReadParams {
-        id: "vm-1".into(),
-        path: "/etc/hostname".into(),
-    };
-    let body = build_read_file_body(&p);
-    assert_eq!(body["path"], "/etc/hostname");
-    assert!(body.get("id").is_none());
 }
 
 // -----------------------------------------------------------------------

--- a/crates/capsem-service/src/api.rs
+++ b/crates/capsem-service/src/api.rs
@@ -215,12 +215,6 @@ pub struct ExecResponse {
     pub exit_code: i32,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-pub struct WriteFileRequest {
-    pub path: String,
-    pub content: String, // Base64 or plain text? For now let's assume plain text or base64 if we detect it.
-}
-
 // ── Files API types (host-side VirtioFS) ─────────────────────────────
 
 /// A single entry in a file listing.
@@ -249,22 +243,10 @@ pub struct FileListResponse {
 }
 
 /// Response for POST /files/{id}/content (upload).
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct UploadResponse {
     pub success: bool,
     pub size: u64,
-}
-
-// ── Legacy vsock file I/O types ──────────────────────────────────────
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ReadFileRequest {
-    pub path: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ReadFileResponse {
-    pub content: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -650,25 +632,19 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // File I/O
+    // Files API
     // -----------------------------------------------------------------------
 
     #[test]
-    fn write_file_request_roundtrip() {
-        let json = json!({"path": "/tmp/f.txt", "content": "data"});
-        let r: WriteFileRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(r.path, "/tmp/f.txt");
-        assert_eq!(r.content, "data");
-    }
-
-    #[test]
-    fn read_file_response_roundtrip() {
-        let r = ReadFileResponse {
-            content: "file contents".into(),
+    fn upload_response_roundtrip() {
+        let r = UploadResponse {
+            success: true,
+            size: 4,
         };
         let json = serde_json::to_string(&r).unwrap();
-        let r2: ReadFileResponse = serde_json::from_str(&json).unwrap();
-        assert_eq!(r2.content, "file contents");
+        let r2: UploadResponse = serde_json::from_str(&json).unwrap();
+        assert!(r2.success);
+        assert_eq!(r2.size, 4);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/capsem-service/src/main.rs
+++ b/crates/capsem-service/src/main.rs
@@ -2666,106 +2666,6 @@ async fn handle_exec(
     }
 }
 
-async fn handle_write_file(
-    State(state): State<Arc<ServiceState>>,
-    Path(id): Path<String>,
-    Json(payload): Json<WriteFileRequest>,
-) -> Result<Json<serde_json::Value>, AppError> {
-    let uds_path = {
-        let instances = state.instances.lock().unwrap();
-        let i = instances
-            .get(&id)
-            .ok_or_else(|| AppError(StatusCode::NOT_FOUND, format!("sandbox not found: {id}")))?;
-        i.uds_path.clone()
-    };
-
-    wait_for_vm_ready(&uds_path, 30, Some(&state), Some(&id))
-        .await
-        .map_err(|e| AppError(StatusCode::INTERNAL_SERVER_ERROR, e))?;
-
-    let id_val = state.next_job_id();
-    let data = payload.content.into_bytes();
-    let res = send_ipc_command(
-        &uds_path,
-        ServiceToProcess::WriteFile {
-            id: id_val,
-            path: payload.path,
-            data,
-        },
-        Some(30),
-    )
-    .await
-    .map_err(|e| AppError(StatusCode::INTERNAL_SERVER_ERROR, e))?;
-
-    match res {
-        ProcessToService::WriteFileResult { success, error, .. } => {
-            if success {
-                Ok(Json(json!({ "success": true })))
-            } else {
-                Err(AppError(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    error.unwrap_or_else(|| "unknown write error".into()),
-                ))
-            }
-        }
-        _ => Err(AppError(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "unexpected IPC response for write_file".to_string(),
-        )),
-    }
-}
-
-async fn handle_read_file(
-    State(state): State<Arc<ServiceState>>,
-    Path(id): Path<String>,
-    Json(payload): Json<ReadFileRequest>,
-) -> Result<Json<ReadFileResponse>, AppError> {
-    let path = &payload.path;
-    let uds_path = {
-        let instances = state.instances.lock().unwrap();
-        let i = instances
-            .get(&id)
-            .ok_or_else(|| AppError(StatusCode::NOT_FOUND, format!("sandbox not found: {id}")))?;
-        i.uds_path.clone()
-    };
-
-    wait_for_vm_ready(&uds_path, 30, Some(&state), Some(&id))
-        .await
-        .map_err(|e| AppError(StatusCode::INTERNAL_SERVER_ERROR, e))?;
-
-    let id_val = state.next_job_id();
-    let res = send_ipc_command(
-        &uds_path,
-        ServiceToProcess::ReadFile {
-            id: id_val,
-            path: path.clone(),
-        },
-        Some(30),
-    )
-    .await
-    .map_err(|e| AppError(StatusCode::INTERNAL_SERVER_ERROR, e))?;
-
-    match res {
-        ProcessToService::ReadFileResult { data, error, .. } => {
-            if let Some(d) = data {
-                Ok(Json(ReadFileResponse {
-                    content: String::from_utf8(d)
-                        .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned()),
-                }))
-            } else {
-                Err(AppError(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    error.unwrap_or_else(|| "unknown read error".into()),
-                ))
-            }
-        }
-        _ => Err(AppError(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "unexpected IPC response for read_file".to_string(),
-        )),
-    }
-}
-
 async fn handle_reload_config(
     State(state): State<Arc<ServiceState>>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
@@ -5006,8 +4906,6 @@ async fn main() -> Result<()> {
         .route("/logs/{id}", get(handle_logs))
         .route("/inspect/{id}", post(handle_inspect))
         .route("/exec/{id}", post(handle_exec))
-        .route("/write_file/{id}", post(handle_write_file))
-        .route("/read_file/{id}", post(handle_read_file))
         .route("/stop/{id}", post(handle_stop))
         .route("/suspend/{id}", post(handle_suspend))
         .route("/delete/{id}", delete(handle_delete))

--- a/crates/capsem-service/src/tests.rs
+++ b/crates/capsem-service/src/tests.rs
@@ -1274,14 +1274,6 @@ fn exec_request_shell_metacharacters() {
 }
 
 #[test]
-fn write_file_request_path_traversal() {
-    let json = serde_json::json!({"path": "../../etc/passwd", "content": "evil"});
-    let req: WriteFileRequest = serde_json::from_value(json).unwrap();
-    assert_eq!(req.path, "../../etc/passwd");
-    // Note: no validation at DTO level -- relies on guest-side enforcement
-}
-
-#[test]
 fn inspect_request_sql_injection() {
     let json = serde_json::json!({"sql": "SELECT * FROM net_events; DROP TABLE net_events; --"});
     let req: InspectRequest = serde_json::from_value(json).unwrap();

--- a/crates/capsem/src/main.rs
+++ b/crates/capsem/src/main.rs
@@ -150,11 +150,12 @@ enum McpCommands {
 enum SessionCommands {
     /// Create and boot a new session
     ///
-    /// Sessions are ephemeral by default and destroyed on delete. Use -n <name> to
-    /// create a persistent session that survives suspend/resume cycles.
+    /// Sessions are ephemeral by default and destroyed on delete. Pass a
+    /// positional name to create a persistent session that survives
+    /// suspend/resume cycles.
     Create {
         /// Name for the session (makes it persistent -- "if you name it, you keep it")
-        #[arg(short = 'n', long)]
+        #[arg(value_name = "NAME")]
         name: Option<String>,
         /// RAM in GB
         #[arg(long, default_value_t = 4)]
@@ -166,23 +167,19 @@ enum SessionCommands {
         #[arg(short = 'e', long = "env")]
         env: Vec<String>,
         /// Clone state from an existing persistent session
-        #[arg(long, alias = "image")]
+        #[arg(long)]
         from: Option<String>,
     },
     /// Open an interactive shell in a session
     ///
     /// With no arguments, creates a temporary session (destroyed on exit).
-    /// Pass a session name/ID or --name to attach to an existing running session.
+    /// Pass a session name/ID to attach to an existing running session.
     Shell {
-        /// Find by name (for persistent sessions)
-        #[arg(short = 'n', long)]
-        name: Option<String>,
         /// Name or ID of the session (positional)
         #[arg(value_name = "SESSION")]
         session: Option<String>,
     },
     /// Resume a suspended session or attach to a running one
-    #[command(alias = "attach")]
     Resume {
         /// Name of the persistent session
         name: String,
@@ -244,7 +241,6 @@ enum SessionCommands {
         dst: String,
     },
     /// List all sessions (running + suspended persistent)
-    #[command(alias = "ls")]
     List {
         /// Print only IDs, one per line (for scripting)
         #[arg(short, long)]
@@ -271,7 +267,6 @@ enum SessionCommands {
         tail: Option<usize>,
     },
     /// Delete a session and all its state
-    #[command(alias = "rm")]
     Delete {
         /// Name or ID of the session
         #[arg(value_name = "SESSION")]
@@ -541,7 +536,7 @@ async fn run_shell(id: &str, run_dir: &std::path::Path) -> Result<()> {
 
     let stream = tokio::net::UnixStream::connect(&sock_path)
         .await
-        .context("failed to connect to sandbox")?;
+        .context("failed to connect to VM session")?;
     let mut std_stream = stream.into_std()?;
     capsem_core::ipc_handshake::negotiate_initiator(
         &mut std_stream,
@@ -1104,7 +1099,7 @@ async fn main() -> Result<()> {
                         if !defunct.is_empty() {
                             println!();
                             println!(
-                                "Defunct:   {} sandbox(es) failed to boot -- run `capsem logs <name>`",
+                                "Defunct:   {} session(s) failed to boot -- run `capsem logs <name>`",
                                 defunct.len()
                             );
                             for s in &defunct {
@@ -1259,18 +1254,15 @@ async fn main() -> Result<()> {
             resp.into_result()?;
             println!("Session suspended.");
         }
-        Commands::Session(SessionCommands::Shell { name, session }) => {
-            let target = name.as_ref().or(session.as_ref());
-            match target {
+        Commands::Session(SessionCommands::Shell { session }) => {
+            match session {
                 Some(t) => {
-                    client::validate_id(t)?;
-                    run_shell(t, &run_dir).await?;
+                    client::validate_id(t.as_str())?;
+                    run_shell(t.as_str(), &run_dir).await?;
                 }
                 None => {
                     // No args: create ephemeral session, attach, destroy on exit
-                    println!(
-                        "[!] Temporary session. Use `capsem create -n <name>` for persistent."
-                    );
+                    println!("[!] Temporary session. Use `capsem create <name>` for persistent.");
                     let req = ProvisionRequest {
                         name: None,
                         ram_mb: 4 * 1024,
@@ -1360,7 +1352,7 @@ async fn main() -> Result<()> {
                 if defunct > 0 {
                     println!();
                     println!(
-                        "{} defunct sandbox(es). Run `capsem logs <name>` to debug.",
+                        "{} defunct session(s). Run `capsem logs <name>` to debug.",
                         defunct
                     );
                 }
@@ -2113,7 +2105,7 @@ mod tests {
 
     #[test]
     fn parse_create_with_name() {
-        let cli = Cli::parse_from(["capsem", "create", "-n", "my-vm"]);
+        let cli = Cli::parse_from(["capsem", "create", "my-vm"]);
         match cli.command.unwrap() {
             Commands::Session(SessionCommands::Create { name, ram, cpu, .. }) => {
                 assert_eq!(name, Some("my-vm".into()));
@@ -2157,12 +2149,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_attach_alias_for_resume() {
-        let cli = Cli::parse_from(["capsem", "attach", "mydev"]);
-        match cli.command.unwrap() {
-            Commands::Session(SessionCommands::Resume { name }) => assert_eq!(name, "mydev"),
-            _ => panic!("expected Resume via attach alias"),
-        }
+    fn parse_attach_alias_rejected() {
+        let cli = Cli::try_parse_from(["capsem", "attach", "mydev"]);
+        assert!(cli.is_err(), "attach alias should be rejected");
     }
 
     #[test]
@@ -2180,24 +2169,17 @@ mod tests {
     fn parse_shell_positional() {
         let cli = Cli::parse_from(["capsem", "shell", "my-vm"]);
         match cli.command.unwrap() {
-            Commands::Session(SessionCommands::Shell { session, name }) => {
+            Commands::Session(SessionCommands::Shell { session }) => {
                 assert_eq!(session, Some("my-vm".into()));
-                assert_eq!(name, None);
             }
             _ => panic!("expected Shell"),
         }
     }
 
     #[test]
-    fn parse_shell_by_name() {
-        let cli = Cli::parse_from(["capsem", "shell", "-n", "mydev"]);
-        match cli.command.unwrap() {
-            Commands::Session(SessionCommands::Shell { name, session }) => {
-                assert_eq!(name, Some("mydev".into()));
-                assert_eq!(session, None);
-            }
-            _ => panic!("expected Shell"),
-        }
+    fn parse_shell_with_name_flag_rejected() {
+        let cli = Cli::try_parse_from(["capsem", "shell", "-n", "mydev"]);
+        assert!(cli.is_err(), "shell -n should be rejected");
     }
 
     #[test]
@@ -2205,8 +2187,7 @@ mod tests {
         // Bare `capsem shell` = temp session + auto-destroy
         let cli = Cli::parse_from(["capsem", "shell"]);
         match cli.command.unwrap() {
-            Commands::Session(SessionCommands::Shell { name, session }) => {
-                assert_eq!(name, None);
+            Commands::Session(SessionCommands::Shell { session }) => {
                 assert_eq!(session, None);
             }
             _ => panic!("expected Shell"),
@@ -2305,6 +2286,12 @@ mod tests {
     }
 
     #[test]
+    fn parse_ls_alias_rejected() {
+        let cli = Cli::try_parse_from(["capsem", "ls"]);
+        assert!(cli.is_err(), "ls alias should be rejected");
+    }
+
+    #[test]
     fn parse_status() {
         // `capsem status` is now the service status command
         let cli = Cli::parse_from(["capsem", "status"]);
@@ -2381,6 +2368,12 @@ mod tests {
             Commands::Session(SessionCommands::Delete { session }) => assert_eq!(session, "vm-123"),
             _ => panic!("expected Delete"),
         }
+    }
+
+    #[test]
+    fn parse_rm_alias_rejected() {
+        let cli = Cli::try_parse_from(["capsem", "rm", "vm-123"]);
+        assert!(cli.is_err(), "rm alias should be rejected");
     }
 
     #[test]
@@ -2722,20 +2715,14 @@ mod tests {
     }
 
     #[test]
-    fn parse_create_with_from_image_alias() {
-        // --image is a backward-compat alias for --from
-        let cli = Cli::parse_from(["capsem", "create", "--image", "old-img"]);
-        match cli.command.unwrap() {
-            Commands::Session(SessionCommands::Create { from, .. }) => {
-                assert_eq!(from, Some("old-img".into()));
-            }
-            _ => panic!("expected Create with --image alias"),
-        }
+    fn parse_create_with_image_alias_rejected() {
+        let cli = Cli::try_parse_from(["capsem", "create", "--image", "old-img"]);
+        assert!(cli.is_err(), "--image alias should be rejected");
     }
 
     #[test]
     fn parse_create_with_name_and_from() {
-        let cli = Cli::parse_from(["capsem", "create", "-n", "my-session", "--from", "my-src"]);
+        let cli = Cli::parse_from(["capsem", "create", "my-session", "--from", "my-src"]);
         match cli.command.unwrap() {
             Commands::Session(SessionCommands::Create { name, from, .. }) => {
                 assert_eq!(name, Some("my-session".into()));
@@ -2743,5 +2730,11 @@ mod tests {
             }
             _ => panic!("expected Create with name and --from"),
         }
+    }
+
+    #[test]
+    fn parse_create_with_name_flag_rejected() {
+        let cli = Cli::try_parse_from(["capsem", "create", "-n", "my-vm"]);
+        assert!(cli.is_err(), "create -n should be rejected");
     }
 }

--- a/docs/src/content/docs/architecture/mcp-gateway.md
+++ b/docs/src/content/docs/architecture/mcp-gateway.md
@@ -70,8 +70,8 @@ sequenceDiagram
 | `capsem_info` | VM details (ID, PID, status, persistent) | `GET /info/{id}` |
 | `capsem_exec` | Run shell command inside VM (timeout param) | `POST /exec/{id}` |
 | `capsem_run` | One-shot: provision + exec + destroy | `POST /run` |
-| `capsem_read_file` | Read file from guest filesystem | `GET /read_file/{id}` |
-| `capsem_write_file` | Write file to guest filesystem | `POST /write_file/{id}` |
+| `capsem_read_file` | Read file from VM workspace | `GET /files/{id}/content?path=<relpath>` |
+| `capsem_write_file` | Write file to VM workspace | `POST /files/{id}/content?path=<relpath>` |
 | `capsem_stop` | Stop VM (persistent: preserve, ephemeral: destroy) | `POST /stop/{id}` |
 | `capsem_suspend` | Suspend VM (save RAM/CPU state) | `POST /suspend/{id}` |
 | `capsem_resume` | Resume stopped persistent VM | `POST /resume/{name}` |

--- a/docs/src/content/docs/architecture/service-architecture.md
+++ b/docs/src/content/docs/architecture/service-architecture.md
@@ -212,8 +212,8 @@ The service exposes a REST API over UDS. The gateway proxies this transparently.
 | POST | `/resume/{name}` | Resume a stopped persistent VM |
 | POST | `/persist/{id}` | Convert ephemeral to persistent |
 | POST | `/purge` | Kill all temp VMs (`all: true` includes persistent) |
-| POST | `/write_file/{id}` | Write file to guest |
-| POST | `/read_file/{id}` | Read file from guest |
+| POST | `/files/{id}/content?path=<relpath>` | Write workspace file |
+| GET | `/files/{id}/content?path=<relpath>` | Read workspace file |
 | GET | `/logs/{id}` | Serial/boot logs |
 | POST | `/inspect/{id}` | SQL query against session.db |
 | DELETE | `/delete/{id}` | Destroy VM and wipe state |

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -63,12 +63,12 @@ Boot a sandboxed VM and get a shell:
 capsem shell
 ```
 
-This creates a temporary Linux session with an air-gapped network. You get a terminal inside the sandbox with Python 3, Node.js, git, and 30+ packages pre-installed. The session is destroyed when you exit.
+This creates a temporary Linux session with an air-gapped network. You get a terminal inside the VM session with Python 3, Node.js, git, and 30+ packages pre-installed. The session is destroyed when you exit.
 
 For a persistent session that survives suspend/resume cycles:
 
 ```sh
-capsem create -n mybox
+capsem create mybox
 capsem shell mybox
 ```
 

--- a/docs/src/content/docs/usage/cli.md
+++ b/docs/src/content/docs/usage/cli.md
@@ -14,15 +14,15 @@ graph TD
     subgraph "Session Commands"
         CREATE["create"]
         SHELL["shell"]
-        RESUME["resume / attach"]
+        RESUME["resume"]
         SUSPEND["suspend"]
         RESTART["restart"]
         EXEC["exec"]
         RUN["run"]
-        LIST["list / ls"]
+        LIST["list"]
         INFO["info"]
         LOGS["logs"]
-        DELETE["delete / rm"]
+        DELETE["delete"]
         FORK["fork"]
         PERSIST["persist"]
         PURGE["purge"]
@@ -49,23 +49,23 @@ graph TD
 
 ### create
 
-Create and boot a new session. Sessions are ephemeral by default. Use `-n <name>` to make it persistent.
+Create and boot a new session. Sessions are ephemeral by default. Pass a positional name to make it persistent.
 
 ```sh
 capsem create                          # ephemeral session
-capsem create -n mybox                 # persistent session
-capsem create -n mybox --ram 8 --cpu 4 # custom resources
+capsem create mybox                    # persistent session
+capsem create mybox --ram 8 --cpu 4    # custom resources
 capsem create --from template          # clone from existing session
 capsem create -e API_KEY=sk-...        # with environment variables
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-n, --name <NAME>` | -- | Name for the session (makes it persistent) |
+| `[NAME]` | -- | Name for the session (makes it persistent) |
 | `--ram <GB>` | 4 | RAM in GB |
 | `--cpu <CORES>` | 4 | CPU cores |
 | `-e, --env <KEY=VALUE>` | -- | Environment variables (repeatable) |
-| `--from <NAME>` | -- | Clone state from existing persistent session (alias: `--image`) |
+| `--from <NAME>` | -- | Clone state from existing persistent session |
 
 ### shell
 
@@ -74,13 +74,11 @@ Open an interactive shell. With no arguments, creates a temporary session that i
 ```sh
 capsem shell              # temp session (destroyed on exit)
 capsem shell mybox        # attach to existing session
-capsem shell -n mybox     # find by name
 capsem shell abc123       # find by ID
 ```
 
-| Flag | Description |
-|------|-------------|
-| `-n, --name <NAME>` | Find by name (persistent sessions) |
+| Arg | Description |
+|-----|-------------|
 | `[SESSION]` | Name or ID of an existing session |
 
 ### resume
@@ -89,7 +87,6 @@ Resume a suspended session or attach to a running one.
 
 ```sh
 capsem resume mybox
-capsem attach mybox       # alias
 ```
 
 | Arg | Description |
@@ -157,7 +154,6 @@ List all sessions (running + suspended persistent).
 
 ```sh
 capsem list
-capsem ls                 # alias
 capsem list -q            # IDs only (for scripting)
 ```
 
@@ -203,7 +199,6 @@ Delete a session and all its state permanently.
 
 ```sh
 capsem delete mybox
-capsem rm mybox           # alias
 ```
 
 | Arg | Description |
@@ -347,7 +342,7 @@ stateDiagram-v2
 | Concept | Description |
 |---------|-------------|
 | **Ephemeral** | Default. Destroyed on delete. Created by `create` (no name) or `shell` (no args) |
-| **Persistent** | Survives suspend/resume. Created by `create -n <name>` or `persist` |
+| **Persistent** | Survives suspend/resume. Created by `create <name>` or `persist` |
 | **Suspended** | RAM + CPU state saved to disk. Resume with `resume` |
 | **Forked** | Point-in-time copy. Use as template with `create --from` |
 

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -54,6 +54,16 @@ function textResponse(text: string, status = 200) {
   });
 }
 
+function blobResponse(text: string, status = 200, contentType = 'text/plain') {
+  const blob = new Blob([text], { type: contentType });
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    blob: () => Promise.resolve(blob),
+    text: () => Promise.resolve(text),
+  });
+}
+
 describe('api', () => {
   beforeEach(() => {
     mockFetch.mockReset();
@@ -222,20 +232,22 @@ describe('api', () => {
       expect(result.exit_code).toBe(0);
     });
 
-    it('readFile sends POST /read_file/{id}', async () => {
-      mockFetch.mockReturnValueOnce(jsonResponse({ content: 'file contents' }));
+    it('readFile sends GET /files/{id}/content', async () => {
+      mockFetch.mockReturnValueOnce(blobResponse('file contents'));
       const result = await api.readFile('vm-1', '/etc/hosts');
       expect(result.content).toBe('file contents');
+      const call = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      expect(call[0]).toContain('/files/vm-1/content?path=etc%2Fhosts');
+      expect(call[1].method).toBeUndefined();
     });
 
-    it('writeFile sends POST /write_file/{id}', async () => {
-      mockFetch.mockReturnValueOnce(jsonResponse(null));
+    it('writeFile sends POST /files/{id}/content', async () => {
+      mockFetch.mockReturnValueOnce(jsonResponse({ success: true, size: 4 }));
       await api.writeFile('vm-1', '/tmp/test', 'data');
       const call = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
-      expect(call[0]).toContain('/write_file/vm-1');
-      const body = JSON.parse(call[1].body);
-      expect(body.path).toBe('/tmp/test');
-      expect(body.content).toBe('data');
+      expect(call[0]).toContain('/files/vm-1/content?path=tmp%2Ftest');
+      expect(call[1].method).toBe('POST');
+      expect(call[1].headers['Content-Type']).toBe('application/octet-stream');
     });
 
     it('inspectQuery sends POST /inspect/{id}', async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -337,12 +337,12 @@ export async function inspectQuery(id: string, sql: string): Promise<InspectResp
 }
 
 export async function readFile(id: string, path: string): Promise<ReadFileResponse> {
-  const resp = await _post(`/read_file/${encodeURIComponent(id)}`, { path });
-  return await resp.json();
+  const result = await getFileContent(id, path);
+  return { content: result.text };
 }
 
 export async function writeFile(id: string, path: string, content: string): Promise<void> {
-  await _post(`/write_file/${encodeURIComponent(id)}`, { path, content });
+  await uploadFile(id, path, content);
 }
 
 // -- Config --

--- a/frontend/src/lib/types/gateway.ts
+++ b/frontend/src/lib/types/gateway.ts
@@ -123,18 +123,8 @@ export interface InspectResponse {
   rows: Record<string, string | number | null>[];
 }
 
-// POST /read_file/{id}
-export interface ReadFileRequest {
-  path: string;
-}
-
+// Compatibility shape used by api.readFile(), now backed by GET /files/{id}/content.
 export interface ReadFileResponse {
-  content: string;
-}
-
-// POST /write_file/{id}
-export interface WriteFileRequest {
-  path: string;
   content: string;
 }
 

--- a/sprints/cli-api-hardening/MASTER.md
+++ b/sprints/cli-api-hardening/MASTER.md
@@ -1,0 +1,25 @@
+# Sprint Master: cli-api-hardening
+
+## Status
+| Item | Status |
+|---|---|
+| Planning (`plan.md`) | Complete |
+| Tracking (`tracker.md`) | In sync |
+| Implementation | Complete for Phase 2 scope |
+| Verification | Rust suites complete; frontend suite blocked locally |
+
+## Scope Snapshot
+- Strict CLI surface (no `-n`, no alias compatibility commands)
+- Canonical file API only (`/files/{id}/content`)
+- Frontend + MCP migrated to canonical file API
+- CLI/API documentation updated to match
+
+## Verification Commands
+- `cargo test -p capsem parse_ -- --nocapture`
+- `cargo test -p capsem-service -- --nocapture`
+- `cargo test -p capsem-mcp -- --nocapture`
+- `npm --prefix frontend test -- src/lib/__tests__/api.test.ts` (blocked: `vitest` not installed locally)
+
+## Open Holds
+- Frontend test run pending dependency install.
+- Some VM-backed Python tests are environment-sensitive (exec-ready boot dependency).

--- a/sprints/cli-api-hardening/plan.md
+++ b/sprints/cli-api-hardening/plan.md
@@ -1,0 +1,55 @@
+# Sprint Plan: CLI API Hardening (Phase 2)
+
+## Goal
+Enforce a strict, no-backward-compat surface for the initial release cleanup:
+- `capsem create` with no name => temporary VM/session
+- `capsem create <name>` => named persistent VM/session
+- remove `-n` naming flag from `shell` and `create`
+- remove compatibility aliases (`attach`, `ls`, `rm`, `--image`)
+- collapse file read/write API onto canonical `/files/{id}/content`
+
+## Scope (this slice)
+- Update clap command definitions in `crates/capsem/src/main.rs`
+- Remove CLI compatibility aliases and add reject tests
+- Remove legacy `/read_file/{id}` and `/write_file/{id}` service routes
+- Migrate frontend file calls to `/files/{id}/content`
+- Migrate MCP file calls to `/files/{id}/content`
+- Refresh CLI/API docs to match strict surface
+
+## Non-goals (next slice)
+- Full taxonomy rename (`sandbox` -> `vm`/`session`) across all internals and DB schema
+- Router naming normalization beyond this file I/O and CLI alias pass
+
+## Files
+- `crates/capsem/src/main.rs`
+- `crates/capsem-service/src/main.rs`
+- `crates/capsem-service/src/api.rs`
+- `crates/capsem-service/src/tests.rs`
+- `crates/capsem-mcp/src/main.rs`
+- `crates/capsem-mcp/src/tests.rs`
+- `frontend/src/lib/api.ts`
+- `frontend/src/lib/types/gateway.ts`
+- `frontend/src/lib/__tests__/api.test.ts`
+- `docs/src/content/docs/usage/cli.md`
+- `docs/src/content/docs/getting-started.md`
+- `docs/src/content/docs/architecture/service-architecture.md`
+- `docs/src/content/docs/architecture/mcp-gateway.md`
+- `sprints/cli-api-hardening/plan.md`
+- `sprints/cli-api-hardening/tracker.md`
+
+## Done Criteria
+- `create` accepts positional optional name
+- `shell` accepts positional optional target only
+- no `-n` parser path for `create` or `shell`
+- no compatibility aliases for `attach`, `ls`, `rm`, `--image`
+- service exposes only canonical file endpoints (`/files/{id}/content`)
+- frontend and MCP file operations use canonical file endpoints
+- docs reflect strict CLI/API surface
+
+## Testing Proof Matrix
+- Unit/contract: `cargo test -p capsem parse_`; `cargo test -p capsem-service`; `cargo test -p capsem-mcp`
+- Functional: CLI parse + service/mcp unit suites
+- Adversarial: alias rejection tests and path sanitization tests
+- E2E/VM: deferred
+- Telemetry: no behavior change expected in telemetry paths
+- Performance: not applicable

--- a/sprints/cli-api-hardening/tracker.md
+++ b/sprints/cli-api-hardening/tracker.md
@@ -1,0 +1,38 @@
+# Sprint: cli-api-hardening
+
+## Tasks
+- [x] Create sprint plan/tracker
+- [x] Change `create` to positional optional name (remove `-n`)
+- [x] Change `shell` to positional optional session only (remove `-n`)
+- [x] Remove CLI compatibility aliases (`attach`, `ls`, `rm`, `--image`)
+- [x] Remove legacy service file routes (`/read_file`, `/write_file`)
+- [x] Migrate frontend file read/write to `/files/{id}/content`
+- [x] Migrate MCP file read/write to `/files/{id}/content`
+- [x] Update CLI/API docs for strict surface
+- [x] Migrate Python integration tests and gateway mock to canonical file routes
+- [x] Run Rust validation suites for touched crates
+- [ ] Run frontend API test suite (blocked: local `vitest` missing)
+
+## Notes
+- This is a strict no-backward-compat pass for initial release cleanup.
+- `cargo test -p capsem -- --nocapture` still has pre-existing unrelated failures:
+  - `setup::tests::corp_config_from_local_file_marks_step_done`
+  - `client::tests::connect_await_startup_waits_for_late_binder`
+- Targeted Python validation:
+  - `uv run pytest -q tests/capsem-gateway/test_gw_proxy_advanced.py::TestProxyEndpointCoverage::test_post_read_file` passed
+  - `uv run pytest -q tests/capsem-service/test_svc_file_io.py::TestFileIO::test_roundtrip` blocked in this environment (VM did not reach exec-ready)
+  - `PYTHONPYCACHEPREFIX=/private/tmp/pycache python3 -m compileall ...` passed for updated test trees
+- Frontend tests are blocked locally because `frontend/node_modules` (including `vitest`) is not installed in this environment.
+
+## Coverage Ledger
+- Unit/contract:
+  - `cargo test -p capsem parse_ -- --nocapture` (62 passed)
+  - `cargo test -p capsem-service -- --nocapture` (89 + 92 passed)
+  - `cargo test -p capsem-mcp -- --nocapture` (100 passed)
+- Functional: CLI parser + service/mcp suite coverage for changed endpoints and argument parsing
+- Adversarial: explicit reject tests for `attach`, `ls`, `rm`, `--image`, `create -n`, `shell -n`
+- E2E/VM: deferred
+- Telemetry: n/a
+- Performance: n/a
+- Missing/deferred: full taxonomy migration (`sandbox`→`session`/`vm`) across all internals and Python integration test endpoint migration
+- Missing/deferred: full taxonomy migration (`sandbox`→`session`/`vm`) across all internals

--- a/tests/capsem-gateway/conftest.py
+++ b/tests/capsem-gateway/conftest.py
@@ -28,6 +28,7 @@ import threading
 import uuid
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -60,6 +61,7 @@ MOCK_VMS = {
         "version": "0.16.1",
     },
 }
+MOCK_FILES = {}
 
 
 class MockServiceHandler(BaseHTTPRequestHandler):
@@ -92,6 +94,7 @@ class MockServiceHandler(BaseHTTPRequestHandler):
         self._send_json({"error": msg}, status=status)
 
     def do_GET(self):
+        parsed = urlparse(self.clean_path)
         if self.clean_path == "/list" or self.clean_path.startswith("/list?"):
             sandboxes = []
             for vm in MOCK_VMS.values():
@@ -118,11 +121,30 @@ class MockServiceHandler(BaseHTTPRequestHandler):
                 self._send_error(404, f"sandbox {vm_id} not found")
         elif self.clean_path.startswith("/logs/"):
             self._send_json({"logs": "mock boot log\n", "serial_logs": None, "process_logs": None})
+        elif parsed.path.startswith("/files/") and parsed.path.endswith("/content"):
+            parts = parsed.path.strip("/").split("/")
+            if len(parts) >= 3:
+                vm_id = parts[1]
+                query = parse_qs(parsed.query)
+                rel_path = query.get("path", [""])[0]
+                key = (vm_id, rel_path)
+                if key not in MOCK_FILES:
+                    self._send_error(404, "file not found")
+                    return
+                data = MOCK_FILES[key]
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+            else:
+                self._send_error(404, f"unknown endpoint: {self.clean_path}")
         else:
             self._send_error(404, f"unknown endpoint: {self.clean_path}")
 
     def do_POST(self):
         body = self._read_body()
+        parsed = urlparse(self.clean_path)
         if self.clean_path == "/provision":
             data = json.loads(body) if body else {}
             vm_id = f"vm-{uuid.uuid4().hex[:8]}"
@@ -133,10 +155,16 @@ class MockServiceHandler(BaseHTTPRequestHandler):
             self._send_json({"stdout": f"mock: {cmd}\n", "stderr": "", "exit_code": 0})
         elif self.clean_path.startswith("/stop/"):
             self._send_json({"ok": True})
-        elif self.clean_path.startswith("/write_file/"):
-            self._send_json({"success": True})
-        elif self.clean_path.startswith("/read_file/"):
-            self._send_json({"content": "mock file content"})
+        elif parsed.path.startswith("/files/") and parsed.path.endswith("/content"):
+            parts = parsed.path.strip("/").split("/")
+            if len(parts) >= 3:
+                vm_id = parts[1]
+                query = parse_qs(parsed.query)
+                rel_path = query.get("path", [""])[0]
+                MOCK_FILES[(vm_id, rel_path)] = body
+                self._send_json({"success": True, "size": len(body)})
+            else:
+                self._send_error(404, f"unknown endpoint: {self.clean_path}")
         elif self.clean_path.startswith("/inspect/"):
             self._send_json({"columns": [], "rows": []})
         elif self.clean_path.startswith("/persist/"):

--- a/tests/capsem-gateway/test_gw_e2e.py
+++ b/tests/capsem-gateway/test_gw_e2e.py
@@ -156,16 +156,11 @@ class TestGatewayFileIO:
 
         try:
             # Write file
-            write_resp = e2e_client.post(f"/write_file/{vm_id}", {
-                "path": "/root/gw-test.txt",
-                "content": "gateway file io test",
-            })
+            write_resp = e2e_client.write_file(vm_id, "/root/gw-test.txt", "gateway file io test")
             assert write_resp is not None
 
             # Read file back
-            read_resp = e2e_client.post(f"/read_file/{vm_id}", {
-                "path": "/root/gw-test.txt",
-            })
+            read_resp = e2e_client.read_file(vm_id, "/root/gw-test.txt")
             assert read_resp is not None
             assert "gateway file io test" in str(read_resp)
         finally:
@@ -181,10 +176,7 @@ class TestGatewayFileIO:
         assert wait_exec_ready_tcp(e2e_client, vm_id, timeout=60)
 
         try:
-            write_resp = e2e_client.post(f"/write_file/{vm_id}", {
-                "path": "/root/special.txt",
-                "content": "line1\nline2\ttab\n",
-            })
+            write_resp = e2e_client.write_file(vm_id, "/root/special.txt", "line1\nline2\ttab\n")
             assert write_resp is not None
 
             exec_resp = e2e_client.post(f"/exec/{vm_id}", {
@@ -213,10 +205,7 @@ class TestGatewayPersistence:
 
         try:
             # Write a marker file
-            e2e_client.post(f"/write_file/{vm_id}", {
-                "path": "/root/persist-marker.txt",
-                "content": "survived-restart",
-            })
+            e2e_client.write_file(vm_id, "/root/persist-marker.txt", "survived-restart")
 
             # Stop
             e2e_client.post(f"/stop/{vm_id}", {})

--- a/tests/capsem-gateway/test_gw_proxy_advanced.py
+++ b/tests/capsem-gateway/test_gw_proxy_advanced.py
@@ -44,16 +44,14 @@ class TestProxyEndpointCoverage:
         assert resp is not None
 
     def test_post_write_file(self, gw_client):
-        """POST /write_file/{id} returns success."""
-        resp = gw_client.post("/write_file/vm-001", {
-            "path": "/root/test.txt",
-            "content": "hello",
-        })
+        """POST /files/{id}/content returns success."""
+        resp = gw_client.write_file("vm-001", "/root/test.txt", "hello")
         assert resp is not None
 
     def test_post_read_file(self, gw_client):
-        """POST /read_file/{id} returns file content."""
-        resp = gw_client.post("/read_file/vm-001", {"path": "/root/test.txt"})
+        """GET /files/{id}/content returns file content."""
+        gw_client.write_file("vm-001", "/root/test.txt", "hello")
+        resp = gw_client.read_file("vm-001", "/root/test.txt")
         assert resp is not None
 
     def test_post_inspect(self, gw_client):

--- a/tests/capsem-isolation/test_filesystem.py
+++ b/tests/capsem-isolation/test_filesystem.py
@@ -11,9 +11,9 @@ def test_write_in_a_absent_in_b(multi_vm_env):
     """File written in VM-A does not exist in VM-B."""
     client, vm_a, vm_b, _ = multi_vm_env
     path = f"/root/iso-{uuid.uuid4().hex[:8]}.txt"
-    client.post(f"/write_file/{vm_a}", {"path": path, "content": "only-in-a"})
+    client.write_file(vm_a, path, "only-in-a")
 
-    resp = client.post(f"/read_file/{vm_b}", {"path": path})
+    resp = client.read_file(vm_b, path)
     assert resp is None or "error" in str(resp).lower(), (
         f"VM-B should not see file from VM-A: {resp}"
     )
@@ -23,11 +23,11 @@ def test_same_path_different_content(multi_vm_env):
     """Same path in two VMs holds different content."""
     client, vm_a, vm_b, _ = multi_vm_env
     path = "/root/shared-name.txt"
-    client.post(f"/write_file/{vm_a}", {"path": path, "content": "content-a"})
-    client.post(f"/write_file/{vm_b}", {"path": path, "content": "content-b"})
+    client.write_file(vm_a, path, "content-a")
+    client.write_file(vm_b, path, "content-b")
 
-    resp_a = client.post(f"/read_file/{vm_a}", {"path": path})
-    resp_b = client.post(f"/read_file/{vm_b}", {"path": path})
+    resp_a = client.read_file(vm_a, path)
+    resp_b = client.read_file(vm_b, path)
     assert resp_a.get("content") == "content-a"
     assert resp_b.get("content") == "content-b"
 
@@ -36,11 +36,11 @@ def test_delete_b_file_persists_in_a(multi_vm_env):
     """Deleting VM-B does not affect files in VM-A."""
     client, vm_a, _, _ = multi_vm_env
     path = f"/root/persist-{uuid.uuid4().hex[:8]}.txt"
-    client.post(f"/write_file/{vm_a}", {"path": path, "content": "survives"})
+    client.write_file(vm_a, path, "survives")
 
     # VM-B deletion happens in other tests or can be simulated
     # For now, just verify A's file survives regardless
-    resp = client.post(f"/read_file/{vm_a}", {"path": path})
+    resp = client.read_file(vm_a, path)
     assert resp.get("content") == "survives"
 
 

--- a/tests/capsem-isolation/test_resume.py
+++ b/tests/capsem-isolation/test_resume.py
@@ -27,16 +27,13 @@ def test_resume_after_neighbor_delete():
         assert wait_exec_ready(client, vm_b), f"VM-B never exec-ready"
 
         # Write a file in VM-A
-        client.post(f"/write_file/{vm_a}", {
-            "path": "/root/resume-test.txt",
-            "content": "still-here",
-        })
+        client.write_file(vm_a, "/root/resume-test.txt", "still-here")
 
         # Delete VM-B
         client.delete(f"/delete/{vm_b}")
 
         # VM-A file should still be there
-        resp = client.post(f"/read_file/{vm_a}", {"path": "/root/resume-test.txt"})
+        resp = client.read_file(vm_a, "/root/resume-test.txt")
         assert resp.get("content") == "still-here"
 
         # VM-A exec should still work

--- a/tests/capsem-lifecycle/test_vm_lifecycle.py
+++ b/tests/capsem-lifecycle/test_vm_lifecycle.py
@@ -60,10 +60,7 @@ class TestGuestShutdownPersistent:
 
         # Write a marker file
         marker = f"shutdown-test-{uuid.uuid4().hex[:8]}"
-        client.post(f"/write_file/{name}", {
-            "path": f"/root/{marker}",
-            "content": f"hello from {marker}",
-        })
+        client.write_file(name, f"/root/{marker}", f"hello from {marker}")
 
         # Guest-initiated shutdown
         client.post(f"/exec/{name}", {
@@ -97,7 +94,7 @@ class TestGuestShutdownPersistent:
         assert wait_exec_ready(client, resumed_id, timeout=EXEC_READY_TIMEOUT), \
             f"VM {resumed_id} never became exec-ready after resume"
 
-        read_resp = client.post(f"/read_file/{resumed_id}", {"path": f"/root/{marker}"})
+        read_resp = client.read_file(resumed_id, f"/root/{marker}")
         assert isinstance(read_resp, dict) and "content" in read_resp, \
             f"read_file returned an error instead of content: {read_resp}"
         assert marker in read_resp["content"], \
@@ -181,10 +178,7 @@ class TestStopResumeE2E:
         assert wait_exec_ready(client, name, timeout=EXEC_READY_TIMEOUT)
 
         marker = f"e2e-{uuid.uuid4().hex[:8]}"
-        client.post(f"/write_file/{name}", {
-            "path": f"/root/{marker}",
-            "content": f"hello from {marker}",
-        })
+        client.write_file(name, f"/root/{marker}", f"hello from {marker}")
 
         # Stop
         client.post(f"/stop/{name}", {})
@@ -196,7 +190,7 @@ class TestStopResumeE2E:
         assert wait_exec_ready(client, resumed_id, timeout=EXEC_READY_TIMEOUT)
 
         # Read back
-        read_resp = client.post(f"/read_file/{resumed_id}", {"path": f"/root/{marker}"})
+        read_resp = client.read_file(resumed_id, f"/root/{marker}")
         assert marker in str(read_resp), \
             f"File did not survive stop + resume: {read_resp}"
 
@@ -248,10 +242,7 @@ class TestSuspendResume:
 
         # Write a marker file
         marker = f"suspend-test-{uuid.uuid4().hex[:8]}"
-        client.post(f"/write_file/{name}", {
-            "path": f"/root/{marker}",
-            "content": f"hello from {marker}",
-        })
+        client.write_file(name, f"/root/{marker}", f"hello from {marker}")
 
         # Suspend via service API
         suspend_resp = client.post(f"/suspend/{name}", {}, timeout=EXEC_READY_TIMEOUT)
@@ -272,7 +263,7 @@ class TestSuspendResume:
             f"VM {resumed_id} never became exec-ready after warm resume"
 
         # Verify file survived
-        read_resp = client.post(f"/read_file/{resumed_id}", {"path": f"/root/{marker}"})
+        read_resp = client.read_file(resumed_id, f"/root/{marker}")
         assert marker in str(read_resp), \
             f"File did not survive suspend + resume: {read_resp}"
 

--- a/tests/capsem-serial/test_lifecycle_benchmark.py
+++ b/tests/capsem-serial/test_lifecycle_benchmark.py
@@ -101,10 +101,7 @@ def _run_fork_benchmark(client):
         assert resp and resp.get("exit_code") == 0, f"apt-get failed: {resp}"
 
         # Write workspace file
-        client.post(f"/write_file/{src}", {
-            "path": "/root/bench.txt",
-            "content": "fork-benchmark-marker",
-        })
+        client.write_file(src, "/root/bench.txt", "fork-benchmark-marker")
 
         # Fork -- time it
         t0 = time.monotonic()

--- a/tests/capsem-service/test_svc_exec_ready.py
+++ b/tests/capsem-service/test_svc_exec_ready.py
@@ -49,7 +49,7 @@ class TestExecImmediatelyAfterProvision:
         client.delete(f"/delete/{vm_id}")
 
     def test_write_file_immediately_after_provision(self, service_env):
-        """POST /write_file/{id} must succeed right after POST /provision."""
+        """POST /files/{id}/content must succeed right after POST /provision."""
         client = service_env.client()
         name = vm_name("wi")
         resp = client.post("/provision", {"name": name, "ram_mb": DEFAULT_RAM_MB, "cpus": DEFAULT_CPUS})
@@ -57,9 +57,10 @@ class TestExecImmediatelyAfterProvision:
         vm_id = resp.get("id", name)
 
         # Immediately write -- server must wait for VM readiness.
-        write_resp = client.post(
-            f"/write_file/{vm_id}",
-            {"path": "/root/race-test.txt", "content": "race-check"},
+        write_resp = client.write_file(
+            vm_id,
+            "/root/race-test.txt",
+            "race-check",
             timeout=HTTP_TIMEOUT,
         )
         assert write_resp is not None, "write_file returned None"
@@ -68,7 +69,7 @@ class TestExecImmediatelyAfterProvision:
         client.delete(f"/delete/{vm_id}")
 
     def test_read_file_immediately_after_provision(self, service_env):
-        """POST /write_file + /read_file must succeed right after POST /provision."""
+        """POST+GET /files/{id}/content must succeed right after POST /provision."""
         client = service_env.client()
         name = vm_name("ri")
         resp = client.post("/provision", {"name": name, "ram_mb": DEFAULT_RAM_MB, "cpus": DEFAULT_CPUS})
@@ -76,16 +77,17 @@ class TestExecImmediatelyAfterProvision:
         vm_id = resp.get("id", name)
 
         # Immediately write then read -- server must wait for VM readiness.
-        write_resp = client.post(
-            f"/write_file/{vm_id}",
-            {"path": "/root/read-probe.txt", "content": "probe-data"},
+        write_resp = client.write_file(
+            vm_id,
+            "/root/read-probe.txt",
+            "probe-data",
             timeout=HTTP_TIMEOUT,
         )
         assert write_resp is not None, "write_file returned None"
 
-        read_resp = client.post(
-            f"/read_file/{vm_id}",
-            {"path": "/root/read-probe.txt"},
+        read_resp = client.read_file(
+            vm_id,
+            "/root/read-probe.txt",
             timeout=HTTP_TIMEOUT,
         )
         assert read_resp is not None, "read_file returned None"

--- a/tests/capsem-service/test_svc_file_io.py
+++ b/tests/capsem-service/test_svc_file_io.py
@@ -9,29 +9,29 @@ class TestFileIO:
 
     def test_roundtrip(self, ready_vm):
         client, name = ready_vm
-        client.post(f"/write_file/{name}", {"path": "/root/rt.txt", "content": "payload-xyz"})
-        resp = client.post(f"/read_file/{name}", {"path": "/root/rt.txt"})
+        client.write_file(name, "/root/rt.txt", "payload-xyz")
+        resp = client.read_file(name, "/root/rt.txt")
         assert resp is not None
         assert resp.get("content") == "payload-xyz"
 
     def test_unicode(self, ready_vm):
         client, name = ready_vm
         text = "caf\u00e9 \u00fc\u00f1\u00ee\u00e7\u00f8\u00f0\u00e9"
-        client.post(f"/write_file/{name}", {"path": "/root/uni.txt", "content": text})
-        resp = client.post(f"/read_file/{name}", {"path": "/root/uni.txt"})
+        client.write_file(name, "/root/uni.txt", text)
+        resp = client.read_file(name, "/root/uni.txt")
         assert resp.get("content") == text
 
     def test_multiline(self, ready_vm):
         client, name = ready_vm
         text = "line1\nline2\nline3\n"
-        client.post(f"/write_file/{name}", {"path": "/root/multi.txt", "content": text})
-        resp = client.post(f"/read_file/{name}", {"path": "/root/multi.txt"})
+        client.write_file(name, "/root/multi.txt", text)
+        resp = client.read_file(name, "/root/multi.txt")
         assert resp.get("content") == text
 
     def test_empty(self, ready_vm):
         client, name = ready_vm
-        client.post(f"/write_file/{name}", {"path": "/root/empty.txt", "content": ""})
-        resp = client.post(f"/read_file/{name}", {"path": "/root/empty.txt"})
+        client.write_file(name, "/root/empty.txt", "")
+        resp = client.read_file(name, "/root/empty.txt")
         assert resp.get("content") == ""
 
     @pytest.mark.skip(reason="slow, team will fix")
@@ -39,32 +39,32 @@ class TestFileIO:
         """1MB payload roundtrip."""
         client, name = ready_vm
         text = "x" * 1_000_000
-        client.post(f"/write_file/{name}", {"path": "/root/large.txt", "content": text})
-        resp = client.post(f"/read_file/{name}", {"path": "/root/large.txt"})
+        client.write_file(name, "/root/large.txt", text)
+        resp = client.read_file(name, "/root/large.txt")
         assert resp.get("content") == text
 
     @pytest.mark.skip(reason="slow, team will fix")
     def test_overwrite(self, ready_vm):
         client, name = ready_vm
-        client.post(f"/write_file/{name}", {"path": "/root/ow.txt", "content": "first"})
-        client.post(f"/write_file/{name}", {"path": "/root/ow.txt", "content": "second"})
-        resp = client.post(f"/read_file/{name}", {"path": "/root/ow.txt"})
+        client.write_file(name, "/root/ow.txt", "first")
+        client.write_file(name, "/root/ow.txt", "second")
+        resp = client.read_file(name, "/root/ow.txt")
         assert resp.get("content") == "second"
 
     @pytest.mark.skip(reason="slow, team will fix")
     def test_nested_path(self, ready_vm):
         client, name = ready_vm
         client.post(f"/exec/{name}", {"command": "mkdir -p /root/deep/nested"})
-        client.post(f"/write_file/{name}", {"path": "/root/deep/nested/f.txt", "content": "deep"})
-        resp = client.post(f"/read_file/{name}", {"path": "/root/deep/nested/f.txt"})
+        client.write_file(name, "/root/deep/nested/f.txt", "deep")
+        resp = client.read_file(name, "/root/deep/nested/f.txt")
         assert resp.get("content") == "deep"
 
     def test_read_nonexistent_file(self, ready_vm):
         client, name = ready_vm
-        resp = client.post(f"/read_file/{name}", {"path": "/root/no-such-file.txt"})
+        resp = client.read_file(name, "/root/no-such-file.txt")
         assert resp is None or "error" in str(resp).lower()
 
     def test_read_nonexistent_vm(self, service_env):
         client = service_env.client()
-        resp = client.post("/read_file/ghost-vm", {"path": "/root/x.txt"})
+        resp = client.read_file("ghost-vm", "/root/x.txt")
         assert resp is None or "error" in str(resp).lower() or "not found" in str(resp).lower()

--- a/tests/capsem-service/test_svc_fork.py
+++ b/tests/capsem-service/test_svc_fork.py
@@ -35,10 +35,7 @@ class TestFork:
             )
 
             marker = f"fork-marker-{uuid.uuid4().hex[:8]}"
-            client.post(f"/write_file/{source}", {
-                "path": "/root/fork-marker.txt",
-                "content": marker,
-            })
+            client.write_file(source, "/root/fork-marker.txt", marker)
 
             child = f"fork-child-{uuid.uuid4().hex[:6]}"
             children.append(child)
@@ -57,7 +54,7 @@ class TestFork:
             assert wait_exec_ready(client, resumed_id, timeout=EXEC_READY_TIMEOUT), (
                 f"forked VM {resumed_id} did not become exec-ready"
             )
-            read = client.post(f"/read_file/{resumed_id}", {"path": "/root/fork-marker.txt"})
+            read = client.read_file(resumed_id, "/root/fork-marker.txt")
             assert read is not None
             assert read.get("content") == marker, (
                 f"marker did not survive fork: {read}"

--- a/tests/capsem-service/test_svc_persistence.py
+++ b/tests/capsem-service/test_svc_persistence.py
@@ -106,13 +106,10 @@ class TestResumeLifecycle:
 
         # 2. Write a file inside the VM
         marker = f"persistence-test-{uuid.uuid4().hex[:8]}"
-        client.post(f"/write_file/{name}", {
-            "path": f"/root/{marker}",
-            "content": f"hello from {marker}",
-        })
+        client.write_file(name, f"/root/{marker}", f"hello from {marker}")
 
         # 3. Verify file exists
-        read_resp = client.post(f"/read_file/{name}", {"path": f"/root/{marker}"})
+        read_resp = client.read_file(name, f"/root/{marker}")
         assert marker in str(read_resp), f"File not found before stop: {read_resp}"
 
         # 4. Stop the VM (preserves state)
@@ -125,7 +122,7 @@ class TestResumeLifecycle:
         wait_exec_ready(client, resumed_id, timeout=EXEC_READY_TIMEOUT)
 
         # 6. Read the file back -- it must survive
-        read_resp2 = client.post(f"/read_file/{resumed_id}", {"path": f"/root/{marker}"})
+        read_resp2 = client.read_file(resumed_id, f"/root/{marker}")
         assert marker in str(read_resp2), (
             f"File did not survive stop+resume! Before: had marker. After: {read_resp2}"
         )

--- a/tests/capsem-session/test_file_events.py
+++ b/tests/capsem-session/test_file_events.py
@@ -17,10 +17,7 @@ def test_fs_events_table_exists(session_db):
 def test_file_create_logged(session_env, session_db):
     """Writing a file via the service should create an fs_event."""
     client, vm_name, _ = session_env
-    client.post(f"/write_file/{vm_name}", {
-        "path": "/root/fstest-create.txt",
-        "content": "logged",
-    })
+    client.write_file(vm_name, "/root/fstest-create.txt", "logged")
     time.sleep(2)
 
     rows = session_db.execute(

--- a/tests/capsem-stress/test_rapid_exec.py
+++ b/tests/capsem-stress/test_rapid_exec.py
@@ -52,15 +52,12 @@ def test_rapid_file_io():
 
         # Write 10 files
         for i in range(10):
-            resp = client.post(f"/write_file/{name}", {
-                "path": f"/root/file-{i}.txt",
-                "content": f"content-{i}",
-            })
+            resp = client.write_file(name, f"/root/file-{i}.txt", f"content-{i}")
             assert resp is not None, f"Write {i} failed"
 
         # Read them all back
         for i in range(10):
-            resp = client.post(f"/read_file/{name}", {"path": f"/root/file-{i}.txt"})
+            resp = client.read_file(name, f"/root/file-{i}.txt")
             assert resp is not None, f"Read {i} failed"
             assert f"content-{i}" in resp.get("content", ""), f"File {i} content mismatch"
 

--- a/tests/helpers/gateway.py
+++ b/tests/helpers/gateway.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 
 from pathlib import Path
+from urllib.parse import quote
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 GATEWAY_BINARY = PROJECT_ROOT / "target/debug/capsem-gateway"
@@ -213,3 +214,71 @@ class TcpHttpClient:
         ]
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout + 5)
         return int(result.stdout.strip()) if result.stdout.strip() else 0
+
+    @staticmethod
+    def _sanitize_path(raw):
+        cleaned = "".join(
+            ch for ch in raw
+            if ch.isascii() and (ch.isalnum() or ch in "._-/")
+        )
+        while "//" in cleaned:
+            cleaned = cleaned.replace("//", "/")
+        cleaned = cleaned.lstrip("/")
+        if not cleaned:
+            raise ValueError("empty path after sanitization")
+        if ".." in cleaned:
+            raise ValueError("path traversal rejected")
+        return cleaned
+
+    @classmethod
+    def _files_content_path(cls, vm_id, path):
+        sanitized = cls._sanitize_path(path)
+        encoded = quote(sanitized, safe="")
+        return f"/files/{vm_id}/content?path={encoded}"
+
+    def write_file(self, vm_id, path, content, timeout=60):
+        endpoint = self._files_content_path(vm_id, path)
+        data = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+        cmd = [
+            "curl", "-s", "-S",
+            "-X", "POST",
+            "-H", f"Authorization: Bearer {self.token}",
+            "-H", "Content-Type: application/octet-stream",
+            "--max-time", str(timeout),
+            "--data-binary", "@-",
+            f"{self.base_url}{endpoint}",
+        ]
+        result = subprocess.run(cmd, input=data, capture_output=True, timeout=timeout + 5)
+        if result.returncode != 0:
+            raise ConnectionError(f"curl failed (rc={result.returncode}): {result.stderr.decode(errors='replace')}")
+        if not result.stdout.strip():
+            return None
+        return json.loads(result.stdout)
+
+    def read_file(self, vm_id, path, timeout=60):
+        endpoint = self._files_content_path(vm_id, path)
+        cmd = [
+            "curl", "-s", "-S", "-o", "-", "-w", "\n__STATUS__%{http_code}",
+            "--max-time", str(timeout),
+            "-H", f"Authorization: Bearer {self.token}",
+            f"{self.base_url}{endpoint}",
+        ]
+        result = subprocess.run(cmd, capture_output=True, timeout=timeout + 5)
+        if result.returncode != 0:
+            raise ConnectionError(f"curl failed (rc={result.returncode}): {result.stderr.decode(errors='replace')}")
+        raw = result.stdout
+        sep = b"\n__STATUS__"
+        idx = raw.rfind(sep)
+        if idx == -1:
+            return None
+        status = int(raw[idx + len(sep):].decode(errors="replace"))
+        body = raw[:idx]
+        if 200 <= status < 300:
+            return {"content": body.decode("utf-8", errors="replace")}
+        try:
+            parsed = json.loads(body.decode("utf-8", errors="replace"))
+            if isinstance(parsed, dict):
+                return parsed
+        except Exception:
+            pass
+        return {"error": body.decode("utf-8", errors="replace")}

--- a/tests/helpers/uds_client.py
+++ b/tests/helpers/uds_client.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess
+from urllib.parse import quote
 
 
 class UdsHttpClient:
@@ -89,3 +90,49 @@ class UdsHttpClient:
         status = int(raw[idx + len(sep):].decode(errors="replace"))
         body = raw[:idx]
         return status, body
+
+    @staticmethod
+    def _sanitize_path(raw):
+        cleaned = "".join(
+            ch for ch in raw
+            if ch.isascii() and (ch.isalnum() or ch in "._-/")
+        )
+        while "//" in cleaned:
+            cleaned = cleaned.replace("//", "/")
+        cleaned = cleaned.lstrip("/")
+        if not cleaned:
+            raise ValueError("empty path after sanitization")
+        if ".." in cleaned:
+            raise ValueError("path traversal rejected")
+        return cleaned
+
+    @classmethod
+    def _files_content_path(cls, vm_id, path):
+        sanitized = cls._sanitize_path(path)
+        encoded = quote(sanitized, safe="")
+        return f"/files/{vm_id}/content?path={encoded}"
+
+    def write_file(self, vm_id, path, content, timeout=60):
+        """Write text/bytes to VM workspace via canonical files endpoint."""
+        endpoint = self._files_content_path(vm_id, path)
+        data = content.encode("utf-8") if isinstance(content, str) else bytes(content)
+        return self.post_bytes(endpoint, data, timeout=timeout)
+
+    def read_file(self, vm_id, path, timeout=60):
+        """Read text file from VM workspace via canonical files endpoint.
+
+        Returns {"content": "..."} on success, or {"error": "..."} on failure.
+        """
+        endpoint = self._files_content_path(vm_id, path)
+        status, body = self.get_bytes(endpoint, timeout=timeout)
+        if status is None:
+            return None
+        if 200 <= status < 300:
+            return {"content": body.decode("utf-8", errors="replace")}
+        try:
+            parsed = json.loads(body.decode("utf-8", errors="replace"))
+            if isinstance(parsed, dict):
+                return parsed
+        except Exception:
+            pass
+        return {"error": body.decode("utf-8", errors="replace")}


### PR DESCRIPTION
## Summary
- remove CLI compatibility aliases (, CHANGELOG.md
CITATION.cff
CLAUDE.md
CONTRIBUTING.md
Cargo.lock
Cargo.toml
GEMINI.md
LATEST_RELEASE.md
LICENSE
README.md
RELEASE.md
SECURITY.md
audit.toml
benchmarks
bootstrap.sh
codecov.yml
config
crates
data
docker
docs
entitlements.plist
frontend
graphics
guest
justfile
pyproject.toml
rust-toolchain.toml
scripts
site
skills
sprints
src
target
test-artifacts
test-dev-null.sh
tests
uv.lock, , ) and enforce positional naming for /
- remove legacy service file routes (, ) and keep canonical 
- migrate frontend and capsem-mcp file read/write mapping to canonical file routes
- migrate Python integration/gateway test surface to canonical file helpers and update gateway mock
- refresh CLI + architecture docs and add sprint hardening artifacts

## Validation
- 
running 62 tests
test client::tests::parse_env_vars_empty ... ok
test client::tests::parse_env_vars_value_with_equals ... ok
test client::tests::parse_env_vars_single ... ok
test client::tests::parse_env_vars_second_entry_invalid ... ok
test client::tests::parse_env_vars_multiple ... ok
test client::tests::parse_env_vars_empty_value ... ok
test client::tests::parse_env_vars_missing_equals ... ok
test tests::parse_doctor ... ok
test tests::parse_doctor_bundle_flag ... ok
test tests::parse_exec_with_timeout ... ok
test tests::parse_create_with_from ... ok
test tests::parse_create_with_name ... ok
test tests::parse_create_with_env_long ... ok
test tests::parse_exec ... ok
test tests::parse_create_with_env ... ok
test tests::parse_attach_alias_rejected ... ok
test tests::parse_completions_bash ... ok
test tests::parse_create_ephemeral ... ok
test tests::parse_create_with_image_alias_rejected ... ok
test tests::parse_create_no_env ... ok
test tests::parse_create_with_name_flag_rejected ... ok
test tests::parse_create_with_resources ... ok
test tests::parse_create_with_name_and_from ... ok
test tests::parse_delete ... ok
test tests::parse_fork ... ok
test tests::parse_info ... ok
test tests::parse_fork_with_description ... ok
test tests::parse_info_json ... ok
test tests::parse_install ... ok
test tests::parse_list ... ok
test tests::parse_list_quiet ... ok
test tests::parse_list_quiet_long ... ok
test tests::parse_logs_with_tail ... ok
test tests::parse_logs_without_tail ... ok
test tests::parse_no_subcommand ... ok
test tests::parse_ls_alias_rejected ... ok
test tests::parse_persist ... ok
test tests::parse_purge ... ok
test tests::parse_restart ... ok
test tests::parse_purge_all ... ok
test tests::parse_resume ... ok
test tests::parse_rm_alias_rejected ... ok
test tests::parse_run ... ok
test tests::parse_run_with_timeout ... ok
test tests::parse_setup_non_interactive ... ok
test tests::parse_setup_with_corp_config ... ok
test tests::parse_setup_with_preset_and_force ... ok
test tests::parse_shell_bare ... ok
test tests::parse_shell_positional ... ok
test tests::parse_status ... ok
test tests::parse_shell_with_name_flag_rejected ... ok
test tests::parse_start ... ok
test tests::parse_stop ... ok
test tests::parse_uninstall ... ok
test tests::parse_uds_path_default_none ... ok
test tests::parse_uninstall_yes ... ok
test tests::parse_suspend ... ok
test tests::parse_uds_path_override ... ok
test tests::parse_update ... ok
test tests::parse_update_assets ... ok
test tests::parse_update_yes ... ok
test tests::parse_version ... ok

test result: ok. 62 passed; 0 failed; 0 ignored; 0 measured; 139 filtered out; finished in 0.01s
- 
running 89 tests
test api::tests::persist_request_roundtrip ... ok
test api::tests::inspect_request_roundtrip ... ok
test api::tests::exec_request_defaults_to_no_timeout ... ok
test api::tests::exec_request_custom_timeout ... ok
test api::tests::provision_request_with_from ... ok
test api::tests::provision_request_without_name ... ok
test api::tests::provision_request_image_alias_deserializes_to_from ... ok
test api::tests::provision_request_ram_cpus_omitted_deserializes_as_none ... ok
test api::tests::provision_request_with_name ... ok
test api::tests::provision_request_env_omitted ... ok
test api::tests::error_response_roundtrip ... ok
test api::tests::exec_response_roundtrip ... ok
test api::tests::list_response_empty ... ok
test api::tests::purge_request_all ... ok
test api::tests::provision_response_roundtrip ... ok
test api::tests::provision_request_with_env ... ok
test api::tests::inspect_response_roundtrip ... ok
test api::tests::logs_response_roundtrip ... ok
test api::tests::purge_request_defaults ... ok
test api::tests::list_response_multiple ... ok
test api::tests::purge_response_roundtrip ... ok
test api::tests::run_request_custom ... ok
test api::tests::run_request_defaults ... ok
test api::tests::sandbox_info_optional_fields_omitted ... ok
test api::tests::upload_response_roundtrip ... ok
test errors::tests::app_error_logged_bare_form_builds_correct_appe ... ok
test fs_utils::tests::sanitize_preserves_hyphens_underscores_dots ... ok
test fs_utils::tests::sanitize_preserves_valid_path ... ok
test fs_utils::tests::sanitize_collapses_slashes ... ok
test fs_utils::tests::sanitize_rejects_dot_dot ... ok
test fs_utils::tests::sanitize_rejects_dot_dot_after_filter ... ok
test fs_utils::tests::sanitize_rejects_embedded_dot_dot ... ok
test fs_utils::tests::sanitize_rejects_empty ... ok
test fs_utils::tests::sanitize_rejects_only_slashes ... ok
test fs_utils::tests::sanitize_strips_leading_slash ... ok
test fs_utils::tests::sanitize_strips_null_bytes ... ok
test fs_utils::tests::sanitize_strips_script_tags ... ok
test fs_utils::tests::sanitize_strips_unicode ... ok
test naming::tests::validate_vm_name_rejects_dot ... ok
test naming::tests::validate_vm_name_rejects_non_ascii ... ok
test naming::tests::validate_vm_name_path_separator ... ok
test naming::tests::validate_vm_name_empty ... ok
test naming::tests::generate_tmp_name_ignores_empty_existing ... ok
test naming::tests::validate_vm_name_spaces ... ok
test naming::tests::generate_tmp_name_passes_validate_vm_name ... ok
test naming::tests::validate_vm_name_starts_with_digit_ok ... ok
test naming::tests::validate_vm_name_starts_with_hyphen ... ok
test naming::tests::generate_tmp_name_falls_back_when_all_adjectives_used ... ok
test naming::tests::validate_vm_name_starts_with_underscore ... ok
test naming::tests::validate_vm_name_too_long ... ok
test naming::tests::validate_vm_name_valid ... ok
test errors::tests::app_error_preserves_empty_message ... ok
test errors::tests::app_error_preserves_arbitrary_status ... ok
test errors::tests::app_error_formats_json ... ok
test errors::tests::app_error_internal_server ... ok
test errors::tests::app_error_conflict ... ok
test naming::tests::generate_tmp_name_has_exactly_two_hyphens ... ok
test naming::tests::generate_tmp_name_ends_with_tmp_suffix ... ok
test registry::tests::suspended_flag_defaults_to_false_when_missing ... ok
test registry::tests::suspended_flag_roundtrips_through_json ... ok
test registry::tests::contains_false_for_missing ... ok
test triage::tests::host_log_path_only_allows_known_names ... ok
test triage::tests::parse_since_accepts_duration_suffixes ... ok
test triage::tests::parse_since_accepts_rfc3339 ... ok
test triage::tests::parse_since_rejects_garbage ... ok
test naming::tests::generate_tmp_name_avoids_existing_first_word ... ok
test registry::tests::load_returns_empty_on_missing_file ... ok
test fs_utils::tests::identify_file_sync_returns_unknown_for_missing_file ... ok
test fs_utils::tests::extract_magika_info_smoke ... ok
test fs_utils::tests::identify_file_sync_round_trips_real_file ... ok
test registry::tests::load_returns_empty_on_corrupt_json ... ok
test registry::tests::get_returns_none_for_missing ... ok
test registry::tests::get_mut_returns_none_for_missing ... ok
test registry::tests::persistent_registry_rejects_duplicate ... ok
test triage::tests::scan_errors_filters_by_since ... ok
test triage::tests::scan_panics_finds_json_panic_line ... ok
test registry::tests::save_writes_atomically_via_temp_rename ... ok
test triage::tests::scan_panics_finds_text_panic_with_thread_name ... ok
test triage::tests::scan_panics_handles_inlined_frame_lines ... ok
test registry::tests::persistent_registry_roundtrip ... ok
test registry::tests::list_iterates_all_registered ... ok
test triage::tests::scan_slow_ops_filters_by_threshold ... ok
test triage::tests::scan_errors_returns_warn_and_error_only ... ok
test triage::tests::scan_panics_handles_panic_with_empty_message ... ok
test registry::tests::resume_clears_suspended_flag_in_registry ... ok
test registry::tests::persistent_registry_get_mut ... ok
test registry::tests::persistent_registry_unregister ... ok
test triage::tests::scan_panics_multiple_in_same_file ... ok
test triage::tests::scan_panics_no_match_on_normal_log ... ok

test result: ok. 89 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s


running 106 tests
test tests::arch_detection_aarch64 ... ok
test tests::classify_ready_outcome_succeeds ... ok
test tests::classify_launchd_transient_routes_to_retry ... ok
test tests::classify_still_booting_timeout_succeeds_with_uds ... ok
test tests::asset_version_path_construction ... ok
test tests::auto_id_format ... ok
test tests::classify_boot_crash_bails_with_500_and_tail ... ok
test tests::classify_provision_error_already_exists_returns_409 ... ok
test startup::tests::parse_version_body_no_body_returns_none ... ok
test tests::classify_provision_error_other_returns_500 ... ok
test startup::tests::parse_version_body_missing_field_returns_none ... ok
test tests::exec_request_shell_metacharacters ... ok
test tests::exec_request_empty_command ... ok
test startup::tests::parse_version_body_extracts_version ... ok
test tests::find_orphan_capsem_pids_returns_empty_on_no_match ... ok
test tests::find_orphan_capsem_pids_skips_non_capsem_process_binaries ... ok
test tests::find_orphan_capsem_pids_matches_capsem_process_under_run_dir ... ok
test tests::find_orphan_capsem_pids_skips_processes_for_other_run_dirs ... ok
test tests::drain_dead_instances_releases_mutex_before_returning ... ok
test tests::drain_dead_instances_empty_when_all_alive ... ok
test tests::handle_get_presets_returns_list ... ok
test tests::archive_failed_restore_checkpoint_moves_checkpoint_aside ... ok
test tests::drain_dead_instances_returns_only_dead_entries ... ok
test tests::cleanup_removes_dead_pid ... ok
test tests::cleanup_mixed_live_and_dead ... ok
test tests::handle_policy_hook_spec_exports_spec0_contract ... ok
test tests::cleanup_keeps_live_pid ... ok
test tests::handle_lint_config_returns_array ... ok
test tests::handle_fork_not_found ... ok
test tests::handle_list_includes_uptime_for_running_vms ... ok
test tests::handle_get_settings_returns_tree ... ok
test tests::handle_save_settings_rejects_unknown_key ... ok
test tests::handle_info_shows_suspended_status ... ok
test tests::download_reads_correct_bytes ... ok
test tests::cull_is_noop_when_under_cap ... ok
test tests::inspect_request_sql_injection ... ok
test tests::handle_list_shows_suspended_status ... ok
test tests::instance_count ... ok
test tests::instance_insert_and_lookup ... ok
test tests::download_nonexistent_file_resolve_ok_but_not_exists ... ok
test tests::launchd_transient_matches_actual_vz_entitlement_error ... ok
test tests::launchd_transient_matches_straight_quote_variant ... ok
test tests::launchd_transient_rejects_other_failures ... ok
test tests::handle_suspend_returns_not_found_for_missing_vm ... ok
test tests::instance_lookup_missing ... ok
test tests::launchd_transient_rejects_partial_match ... ok
test tests::instance_remove ... ok
test tests::download_binary_preserves_content ... ok
test tests::handle_save_settings_accepts_mcp_policy_rule_object ... ok
test tests::long_vm_name_falls_back_to_tmp_socket ... ok
test tests::handle_fork_from_persistent_registry ... ok
test tests::handle_fork_duplicate_returns_conflict ... ok
test tests::handle_fork_creates_persistent_sandbox ... ok
test tests::cull_ignores_non_failed_dirs ... ok
test tests::handle_save_settings_accepts_model_policy_rule_object ... ok
test tests::list_dir_respects_depth_limit ... ok
test tests::cull_keeps_newest_and_prunes_oldest ... ok
test tests::main_db_path_resolves_to_sessions_dir ... ok
test tests::process_env_allowlist_forwards_mcp_timeout_knobs ... ok
test tests::list_dir_returns_correct_structure ... ok
test tests::list_dir_skips_system_but_shows_hidden ... ok
test tests::list_dir_sorts_dirs_first_then_alphabetical ... ok
test tests::handle_save_settings_accepts_policy_rule_object ... ok
test tests::provision_request_empty_name ... ok
test tests::provision_request_name_with_path_separator ... ok
test tests::provision_request_no_name ... ok
test tests::handle_save_settings_rejects_invalid_policy_condition ... ok
test tests::handle_save_settings_rejects_policy_rule_callback_mismatch ... ok
test tests::next_job_id_increments ... ok
test tests::next_job_id_starts_at_1 ... ok
test tests::handle_stats_returns_global_data ... ok
test tests::mcp_refresh_surfaces_process_failure ... ok
test tests::sandbox_info_new_defaults_telemetry_to_none ... ok
test tests::sandbox_info_backwards_compatible_deserialization ... ok
test tests::sandbox_info_telemetry_fields_omitted_when_none ... ok
test tests::sandbox_info_telemetry_fields_serialize_when_present ... ok
test tests::startup_manifest_loader_rejects_invalid_signature ... ok
test tests::startup_manifest_loader_rejects_unsigned_manifest ... ok
test tests::stats_response_serializes ... ok
test tests::timeline_allowed_layers_include_policy_v2_tables ... ok
test tests::timeline_column_helpers_emit_policy_suffix_for_current_schema ... ok
test tests::timeline_column_helpers_fallback_for_legacy_schema ... ok
test startup::tests::startup_lock_is_mutually_exclusive ... ok
test tests::preserve_is_idempotent_when_called_twice ... ok
test tests::next_job_id_unique_across_many ... ok
test tests::preserve_outcome_already_absent_when_dir_does_not_exist ... ok
test tests::preserve_renames_session_dir_and_keeps_logs ... ok
test tests::upload_path_traversal_blocked ... ok
test tests::preserve_outcome_preserved_when_dir_exists ... ok
test tests::provision_accepts_name_just_under_uds_limit ... ok
test tests::reload_config_returns_structured_failed_session_state ... ok
test tests::provision_persistent_rejects_duplicate_name ... ok
test tests::provision_rejects_nonexistent_source_sandbox ... ok
test tests::provision_persistent_validates_name ... ok
test tests::resolve_rejects_unknown_vm ... ok
test tests::provision_short_name_passes_path_check ... ok
test tests::resolve_rejects_symlink_escape ... ok
test tests::resolve_valid_path_inside_workspace ... ok
test tests::short_vm_name_uses_run_dir ... ok
test tests::handle_suspend_rejects_ephemeral_vm ... ok
test tests::upload_creates_file_with_content ... ok
test tests::upload_creates_parent_directories ... ok
test tests::timeline_existing_tables_lists_policy_v2_tables ... ok
test tests::wait_for_vm_ready_detects_ready_within_tight_overshoot ... ok
test tests::triage_session_db_surfaces_policy_v2_signals ... ok
test tests::timeline_handler_returns_policy_v2_layers_and_null_trace_rows ... ok

test result: ok. 106 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.37s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
running 101 tests
test tests::create_body_includes_from_clone_source ... ok
test tests::exec_body_zero_timeout ... ok
test tests::create_body_unnamed_is_ephemeral ... ok
test tests::create_body_includes_env_when_present ... ok
test tests::create_params_serializes_camel ... ok
test tests::exec_body_custom_timeout ... ok
test tests::exec_body_default_timeout ... ok
test tests::create_body_omits_resources_when_absent ... ok
test tests::create_body_includes_resources_when_present ... ok
test tests::create_body_named_is_persistent ... ok
test tests::exec_params_roundtrip ... ok
test tests::exec_params_empty_command ... ok
test tests::create_params_zero_resources ... ok
test tests::create_params_huge_resources ... ok
test tests::create_params_all_optional ... ok
test tests::create_params_camel_case ... ok
test tests::create_params_without_env ... ok
test tests::create_params_with_env ... ok
test tests::exec_params_shell_metacharacters ... ok
test tests::exec_params_timeout_large ... ok
test tests::exec_params_timeout_zero ... ok
test tests::exec_params_with_timeout ... ok
test tests::exec_params_very_long_command ... ok
test tests::file_read_params_path_traversal ... ok
test tests::file_read_params_roundtrip ... ok
test tests::file_write_params_path_traversal ... ok
test tests::file_write_params_roundtrip ... ok
test tests::fork_body_with_description ... ok
test tests::fork_body_without_description ... ok
test tests::format_service_response_null_value_is_ok ... ok
test tests::format_service_response_ok_pretty_prints ... ok
test tests::format_service_response_array_value_is_ok ... ok
test tests::format_service_response_err_returns_message ... ok
test tests::format_service_response_ok_with_non_string_error_field_is_ok ... ok
test tests::format_service_response_ok_with_embedded_error_is_err ... ok
test tests::grep_lines_empty_input ... ok
test tests::grep_lines_brackets_literal ... ok
test tests::grep_lines_all_lines_match ... ok
test tests::grep_lines_empty_pattern_matches_all ... ok
test tests::grep_lines_filters_case_insensitive ... ok
test tests::grep_lines_mixed_case_pattern ... ok
test tests::grep_lines_no_match ... ok
test tests::grep_lines_preserves_line_order ... ok
test tests::grep_lines_regex_metacharacters_are_literal ... ok
test tests::grep_lines_single_line_match ... ok
test tests::grep_lines_single_line_no_match ... ok
test tests::grep_lines_special_chars_literal ... ok
test tests::grep_lines_trailing_newline ... ok
test tests::grep_lines_unicode ... ok
test tests::grep_lines_whitespace_pattern ... ok
test tests::grep_log_fields_filters_all_log_keys ... ok
test tests::grep_log_fields_leaves_non_log_keys ... ok
test tests::grep_log_fields_missing_optional_keys ... ok
test tests::grep_log_fields_no_match_empties_strings ... ok
test tests::id_params_roundtrip ... ok
test tests::id_params_with_null_bytes ... ok
test tests::inspect_params_roundtrip ... ok
test tests::inspect_params_sql_injection ... ok
test tests::inspect_schema_contains_create_table ... ok
test tests::logs_params_grep_empty_string ... ok
test tests::logs_params_grep_special_chars ... ok
test tests::logs_params_with_grep ... ok
test tests::logs_params_with_grep_and_tail ... ok
test tests::logs_params_with_tail ... ok
test tests::logs_params_without_grep ... ok
test tests::path_construction_with_empty_id ... ok
test tests::path_construction_with_slashes ... ok
test tests::path_construction_with_traversal ... ok
test tests::persist_body_contains_name ... ok
test tests::inspect_schema_has_all_tables ... ok
test tests::purge_body_all_defaults_to_false ... ok
test tests::purge_body_all_true_preserved ... ok
test tests::query_string_empty_when_no_params ... ok
test tests::query_string_encodes_ampersand_in_value ... ok
test tests::query_string_encodes_other_reserved_chars ... ok
test tests::query_string_encodes_space_in_value ... ok
test tests::query_string_leaves_safe_chars_unencoded ... ok
test tests::query_string_multiple_params_separated_by_amp ... ok
test tests::query_string_single_param_no_trailing_amp ... ok
test tests::query_string_skips_none_values ... ok
test tests::resolve_run_dir_default_delegates_to_capsem_core ... ok
test tests::resolve_run_dir_prefers_override ... ok
test tests::resolve_uds_path_falls_back_to_run_dir ... ok
test tests::resolve_uds_path_prefers_override ... ok
test tests::run_body_custom_timeout ... ok
test tests::run_body_default_timeout_is_60 ... ok
test tests::run_body_with_env ... ok
test tests::run_body_without_env_omits_key ... ok
test tests::service_logs_params_empty ... ok
test tests::server_info_name_and_version ... ok
test tests::service_logs_params_grep_special_chars ... ok
test tests::service_logs_params_with_grep ... ok
test tests::service_logs_params_with_tail ... ok
test tests::tail_lines_basic ... ok
test tests::tail_lines_empty ... ok
test tests::tail_lines_exact ... ok
test tests::tail_lines_more_than_available ... ok
test tests::tail_log_fields_applies_to_all ... ok
test tests::uds_path_override_logic ... ok
test tests::timeline_tool_schema_exposes_policy_v2_layers ... ok
test tests::tool_router_registers_all_tools ... ok

test result: ok. 101 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- .                                                                        [100%]
1 passed in 0.78s
- .                                                                        [100%]
1 passed in 0.78s
- Listing 'tests/helpers'...
Compiling 'tests/helpers/gateway.py'...
Compiling 'tests/helpers/service.py'...
Compiling 'tests/helpers/uds_client.py'...
Listing 'tests/capsem-service'...
Compiling 'tests/capsem-service/test_companion_lifecycle.py'...
Compiling 'tests/capsem-service/test_svc_exec_ready.py'...
Compiling 'tests/capsem-service/test_svc_file_io.py'...
Compiling 'tests/capsem-service/test_svc_fork.py'...
Compiling 'tests/capsem-service/test_svc_persistence.py'...
Compiling 'tests/capsem-service/test_svc_settings.py'...
Listing 'tests/capsem-gateway'...
Compiling 'tests/capsem-gateway/conftest.py'...
Compiling 'tests/capsem-gateway/test_gw_auth.py'...
Compiling 'tests/capsem-gateway/test_gw_e2e.py'...
Compiling 'tests/capsem-gateway/test_gw_proxy.py'...
Compiling 'tests/capsem-gateway/test_gw_proxy_advanced.py'...
Listing 'tests/capsem-lifecycle'...
Compiling 'tests/capsem-lifecycle/test_vm_lifecycle.py'...
Listing 'tests/capsem-isolation'...
Compiling 'tests/capsem-isolation/test_filesystem.py'...
Compiling 'tests/capsem-isolation/test_resume.py'...
Listing 'tests/capsem-stress'...
Compiling 'tests/capsem-stress/test_rapid_exec.py'...
Listing 'tests/capsem-session'...
Compiling 'tests/capsem-session/test_check_session_compat.py'...
Compiling 'tests/capsem-session/test_file_events.py'...
Listing 'tests/capsem-serial'...
Compiling 'tests/capsem-serial/test_lifecycle_benchmark.py'...

## Notes
- one VM-backed targeted test remained environment-sensitive in this run ( stalled waiting for exec-ready)
- frontend vitest execution remained blocked in this environment (local  not installed)
