### PR TITLE
fix: satisfy release clippy gate

### DIFF
--- a/crates/capsem-admin/src/main.rs
+++ b/crates/capsem-admin/src/main.rs
@@ -1600,14 +1600,16 @@ fn validate_assets_channel_health(
     validate_profile_catalog_artifact(
         dist,
         &expected_profile_source,
-        &expected_profile_hash,
-        &expected_profile_revision,
-        &manifest.binaries.current,
-        &manifest.assets.current,
-        &current_release.min_binary,
-        current_binary_release
-            .map(|release| release.min_assets.as_str())
-            .unwrap_or(""),
+        ProfileCatalogExpectations {
+            hash: &expected_profile_hash,
+            revision: &expected_profile_revision,
+            current_binary: &manifest.binaries.current,
+            current_assets: &manifest.assets.current,
+            min_binary: &current_release.min_binary,
+            min_assets: current_binary_release
+                .map(|release| release.min_assets.as_str())
+                .unwrap_or(""),
+        },
     )?;
     require_json_str(
         health,
@@ -2102,15 +2104,19 @@ fn require_json_string(root: &serde_json::Value, path: &[&str]) -> Result<String
         .ok_or_else(|| anyhow!("health.json missing {}", path.join(".")))
 }
 
+struct ProfileCatalogExpectations<'a> {
+    hash: &'a str,
+    revision: &'a str,
+    current_binary: &'a str,
+    current_assets: &'a str,
+    min_binary: &'a str,
+    min_assets: &'a str,
+}
+
 fn validate_profile_catalog_artifact(
     dist: &Path,
     source: &str,
-    expected_hash: &str,
-    expected_revision: &str,
-    expected_current_binary: &str,
-    expected_current_assets: &str,
-    expected_min_binary: &str,
-    expected_min_assets: &str,
+    expected: ProfileCatalogExpectations<'_>,
 ) -> Result<()> {
     if !source.starts_with("/profiles/releases/") || !source.ends_with("/catalog.json") {
         return Err(anyhow!(
@@ -2123,7 +2129,7 @@ fn validate_profile_catalog_artifact(
     let bytes =
         fs::read(&path).with_context(|| format!("read profile catalog {}", path.display()))?;
     let actual_hash = blake3::hash(&bytes).to_hex().to_string();
-    if actual_hash != expected_hash {
+    if actual_hash != expected.hash {
         return Err(anyhow!("health.json profile catalog hash mismatch"));
     }
     let text = std::str::from_utf8(&bytes)
@@ -2144,7 +2150,7 @@ fn validate_profile_catalog_artifact(
     require_json_str(
         &catalog,
         &["revision"],
-        expected_revision,
+        expected.revision,
         "profile catalog revision mismatch",
     )?;
     require_json_str(
@@ -2156,37 +2162,37 @@ fn validate_profile_catalog_artifact(
     require_json_str(
         &catalog,
         &["current_binary"],
-        expected_current_binary,
+        expected.current_binary,
         "profile catalog current binary mismatch",
     )?;
     require_json_str(
         &catalog,
         &["current_assets"],
-        expected_current_assets,
+        expected.current_assets,
         "profile catalog current assets mismatch",
     )?;
     require_json_str(
         &catalog,
         &["compatibility", "binary"],
-        expected_current_binary,
+        expected.current_binary,
         "profile catalog binary compatibility mismatch",
     )?;
     require_json_str(
         &catalog,
         &["compatibility", "assets"],
-        expected_current_assets,
+        expected.current_assets,
         "profile catalog asset compatibility mismatch",
     )?;
     require_json_str(
         &catalog,
         &["compatibility", "min_binary"],
-        expected_min_binary,
+        expected.min_binary,
         "profile catalog min binary mismatch",
     )?;
     require_json_str(
         &catalog,
         &["compatibility", "min_assets"],
-        expected_min_assets,
+        expected.min_assets,
         "profile catalog min assets mismatch",
     )?;
     require_json_bool(
@@ -3437,11 +3443,13 @@ fn materialize_profile_config(args: &ProfileMaterializeArgs) -> Result<ProfileMa
                 .ok_or_else(|| anyhow!("materialized {arch} rootfs hash is unresolved"))?
         };
         materialize_profile_obom_descriptor(
-            &args.assets_dir,
-            &args.manifest,
-            &manifest.assets.current,
-            &arch,
-            manifest_assets,
+            ProfileObomMaterializeInputs {
+                assets_dir: &args.assets_dir,
+                manifest_url: &args.manifest,
+                asset_version: &manifest.assets.current,
+                arch: &arch,
+                manifest_assets,
+            },
             rootfs_hash,
             &mut profile,
             &mut materialized_obom,
@@ -3581,30 +3589,34 @@ fn materialize_profile_file_descriptors(
     Ok(())
 }
 
+struct ProfileObomMaterializeInputs<'a> {
+    assets_dir: &'a Path,
+    manifest_url: &'a str,
+    asset_version: &'a str,
+    arch: &'a str,
+    manifest_assets: &'a std::collections::HashMap<String, capsem_core::asset_manager::AssetEntry>,
+}
+
 fn materialize_profile_obom_descriptor(
-    assets_dir: &Path,
-    manifest_url: &str,
-    asset_version: &str,
-    arch: &str,
-    manifest_assets: &std::collections::HashMap<String, capsem_core::asset_manager::AssetEntry>,
+    inputs: ProfileObomMaterializeInputs<'_>,
     rootfs_hash: String,
     profile: &mut ProfileConfigFile,
     reports: &mut Vec<ProfileMaterializedObomReport>,
 ) -> Result<()> {
-    let Some(entry) = manifest_assets.get("obom.cdx.json") else {
+    let Some(entry) = inputs.manifest_assets.get("obom.cdx.json") else {
         return Ok(());
     };
     let obom_url = materialized_asset_url(
-        assets_dir,
-        manifest_url,
-        asset_version,
-        arch,
+        inputs.assets_dir,
+        inputs.manifest_url,
+        inputs.asset_version,
+        inputs.arch,
         "obom.cdx.json",
         &entry.hash,
         entry.size,
     )?;
     let (generator, generator_version) = if obom_url.starts_with("file://") {
-        let obom_path = assets_dir.join(arch).join("obom.cdx.json");
+        let obom_path = inputs.assets_dir.join(inputs.arch).join("obom.cdx.json");
         let obom_path = obom_path
             .canonicalize()
             .with_context(|| format!("canonicalize {}", obom_path.display()))?;
@@ -3627,9 +3639,9 @@ fn materialize_profile_obom_descriptor(
             arch: BTreeMap::new(),
         })
         .arch
-        .insert(arch.to_string(), descriptor.clone());
+        .insert(inputs.arch.to_string(), descriptor.clone());
     reports.push(ProfileMaterializedObomReport {
-        arch: arch.to_string(),
+        arch: inputs.arch.to_string(),
         url: descriptor.url,
         hash: descriptor.hash,
         size: descriptor.size,

--- a/crates/capsem-service/src/startup.rs
+++ b/crates/capsem-service/src/startup.rs
@@ -127,7 +127,7 @@ impl VzHostLock {
                 .read(true)
                 .write(true)
                 .truncate(false)
-                .open(&path)
+                .open(path)
                 .with_context(|| format!("failed to open vz host lock {}", path.display()))?;
             match Flock::lock(file, arg) {
                 Ok(flock) => return Ok(Some(Self { _flock: flock })),

--- a/crates/capsem-tray/src/main.rs
+++ b/crates/capsem-tray/src/main.rs
@@ -39,7 +39,7 @@ struct Args {
 
 /// Message from the async poller to the main thread.
 enum PollResult {
-    Status(gateway::StatusResponse),
+    Status(Box<gateway::StatusResponse>),
     Unavailable(String),
 }
 
@@ -170,6 +170,7 @@ fn main() -> Result<()> {
         while let Ok(result) = poll_rx.try_recv() {
             match result {
                 PollResult::Status(status) => {
+                    let status = *status;
                     let service_available = menu::service_available(&status);
                     let desired_state = if service_available {
                         TrayState::Idle
@@ -289,7 +290,7 @@ async fn async_worker(
                 // Poll status
                 match client.status().await {
                     Ok(status) => {
-                        let _ = poll_tx.send(PollResult::Status(status));
+                        let _ = poll_tx.send(PollResult::Status(Box::new(status)));
                     }
                     Err(e) => {
                         warn!("status poll failed: {e}");
@@ -312,7 +313,7 @@ async fn async_worker(
                 poll_interval.reset(); // Optional: reset interval if we want to delay next poll
                 // OR just poll immediately:
                 if let Ok(status) = client.status().await {
-                     let _ = poll_tx.send(PollResult::Status(status));
+                     let _ = poll_tx.send(PollResult::Status(Box::new(status)));
                 }
             }
         }

--- a/crates/capsem/src/update.rs
+++ b/crates/capsem/src/update.rs
@@ -654,6 +654,7 @@ fn update_target_blocked_reason(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn update_check_from_release_health(
     health: &ReleaseChannelHealth,
     checked_at: u64,
@@ -782,25 +783,46 @@ fn binary_installer_for_layout(
     files: &[ReleaseChannelBinaryFile],
     install_layout: &InstallLayout,
 ) -> Option<BinaryInstaller> {
-    let (layout_name, matches_layout): (&str, Box<dyn Fn(&str) -> bool>) = match install_layout {
-        InstallLayout::MacosPkg => ("macos_pkg", Box::new(|name| name.ends_with(".pkg"))),
+    enum LayoutMatcher {
+        MacosPkg,
+        LinuxDeb { suffix: String },
+    }
+
+    impl LayoutMatcher {
+        fn name(&self) -> &'static str {
+            match self {
+                Self::MacosPkg => "macos_pkg",
+                Self::LinuxDeb { .. } => "linux_deb",
+            }
+        }
+
+        fn matches(&self, name: &str) -> bool {
+            match self {
+                Self::MacosPkg => name.ends_with(".pkg"),
+                Self::LinuxDeb { suffix } => name.ends_with(suffix),
+            }
+        }
+    }
+
+    let matcher = match install_layout {
+        InstallLayout::MacosPkg => LayoutMatcher::MacosPkg,
         InstallLayout::LinuxDeb => {
             let suffix = format!("_{}.deb", deb_arch());
-            ("linux_deb", Box::new(move |name| name.ends_with(&suffix)))
+            LayoutMatcher::LinuxDeb { suffix }
         }
         InstallLayout::UserDir | InstallLayout::Development => return None,
     };
 
     files
         .iter()
-        .filter(|file| matches_layout(&file.name))
+        .filter(|file| matcher.matches(&file.name))
         .filter(|file| {
             let installer = BinaryInstaller {
                 name: file.name.clone(),
                 url: file.url.clone(),
                 sha256: file.sha256.clone(),
                 size: file.size,
-                install_layout: layout_name.to_string(),
+                install_layout: matcher.name().to_string(),
             };
             validate_binary_installer_metadata(&installer).is_ok()
         })
@@ -810,7 +832,7 @@ fn binary_installer_for_layout(
             url: file.url.clone(),
             sha256: file.sha256.clone(),
             size: file.size,
-            install_layout: layout_name.to_string(),
+            install_layout: matcher.name().to_string(),
         })
 }
 
@@ -1493,14 +1515,14 @@ async fn hydrate_installed_assets(assets_dir: &Path) -> Result<()> {
     let binary_version = env!("CARGO_PKG_VERSION");
 
     println!("Refreshing VM assets into {}...", assets_dir.display());
-    if let Some(local_source) = local_manifest_asset_source(&assets_dir)? {
+    if let Some(local_source) = local_manifest_asset_source(assets_dir)? {
         println!("Using local asset source {}...", local_source.display());
         let copied = capsem_core::asset_manager::copy_missing_local_assets(
             &manifest,
             binary_version,
             arch,
             &local_source,
-            &assets_dir,
+            assets_dir,
             |p| {
                 if p.done {
                     let mb = p.bytes_done as f64 / 1_048_576.0;
@@ -1522,7 +1544,7 @@ async fn hydrate_installed_assets(assets_dir: &Path) -> Result<()> {
         &manifest,
         binary_version,
         arch,
-        &assets_dir,
+        assets_dir,
         |p| {
             if p.done {
                 let mb = p.bytes_done as f64 / 1_048_576.0;
@@ -2547,6 +2569,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::await_holding_lock)]
     async fn download_binary_installer_fetches_verifies_and_caches() {
         let _lock = crate::lock_test_env();
         let home = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary
- fix clippy warnings that blocked the first v1.4 release cut attempt
- keep the changes scoped to mechanical warning fixes in tray, admin, update, and service startup code
- leave unrelated benchmark and uv.lock dirt unstaged

## Verification
- cargo fmt
- cargo clippy --workspace --all-targets -- -D warnings

## Release note
The first just cut-release attempt stopped before stamping/tagging/pushing because local clippy failed. No v1.4 tag or release was created.