### PR TITLE
Add Summer 2026 marketing holding page

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,16 @@ permissions:
 
 jobs:
   fast-gate:
+    needs: docs-build
+    if: ${{ needs.docs-build.outputs.web_only != 'true' }}
     uses: ./.github/workflows/fast-gate.yaml
 
   # ---------------------------------------------------------------------------
   # Linux: compile + test KVM hypervisor backend (cfg(target_os = "linux"))
   # ---------------------------------------------------------------------------
   test-linux:
+    needs: docs-build
+    if: ${{ needs.docs-build.outputs.web_only != 'true' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -127,6 +131,8 @@ jobs:
   # macOS: full test suite (Apple VZ backend, frontend, Python, coverage)
   # ---------------------------------------------------------------------------
   test:
+    needs: docs-build
+    if: ${{ needs.docs-build.outputs.web_only != 'true' }}
     runs-on: macos-14
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -350,6 +356,8 @@ jobs:
   # Install e2e: Docker-based install layout + systemd tests (Linux)
   # ---------------------------------------------------------------------------
   test-install:
+    needs: docs-build
+    if: ${{ needs.docs-build.outputs.web_only != 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -420,8 +428,36 @@ jobs:
   # ---------------------------------------------------------------------------
   docs-build:
     runs-on: ubuntu-latest
+    outputs:
+      web_only: ${{ steps.scope.outputs.web_only }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          fetch-depth: 0
+
+      - name: Classify pull request scope
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "$EVENT_NAME" != pull_request ]; then
+            echo "web_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          web_only=true
+          while IFS= read -r path; do
+            case "$path" in
+              README.md|later/*|site/*|docs/*|.github/workflows/site.yaml|.github/workflows/docs.yaml|.github/workflows/ci.yaml|scripts/check-docs-holding-build.py|tests/test_docs_holding_contract.py|tests/test_release_doctor_contract.py)
+                ;;
+              *)
+                web_only=false
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA"...HEAD)
+          echo "web_only=$web_only" >> "$GITHUB_OUTPUT"
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
         with:
@@ -459,6 +495,8 @@ jobs:
         run: bash scripts/check-web-surface.sh site
 
   release-site-build:
+    needs: docs-build
+    if: ${{ needs.docs-build.outputs.web_only != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
@@ -517,7 +555,9 @@ jobs:
           DOCS_BUILD_RESULT: ${{ needs.docs-build.result }}
           SITE_BUILD_RESULT: ${{ needs.site-build.result }}
           RELEASE_SITE_BUILD_RESULT: ${{ needs.release-site-build.result }}
+          WEB_ONLY: ${{ needs.docs-build.outputs.web_only }}
         run: |
+          echo "web-only:     $WEB_ONLY"
           echo "fast-gate:    $FAST_GATE_RESULT"
           echo "test-linux:   $TEST_LINUX_RESULT"
           echo "test:         $TEST_MACOS_RESULT"
@@ -526,10 +566,19 @@ jobs:
           echo "site-build:   $SITE_BUILD_RESULT"
           echo "release-site-build: $RELEASE_SITE_BUILD_RESULT"
 
-          test "$FAST_GATE_RESULT" = success
-          test "$TEST_LINUX_RESULT" = success
-          test "$TEST_MACOS_RESULT" = success
-          test "$TEST_INSTALL_RESULT" = success
           test "$DOCS_BUILD_RESULT" = success
           test "$SITE_BUILD_RESULT" = success
-          test "$RELEASE_SITE_BUILD_RESULT" = success
+
+          if [ "$WEB_ONLY" = true ]; then
+            test "$FAST_GATE_RESULT" = skipped
+            test "$TEST_LINUX_RESULT" = skipped
+            test "$TEST_MACOS_RESULT" = skipped
+            test "$TEST_INSTALL_RESULT" = skipped
+            test "$RELEASE_SITE_BUILD_RESULT" = skipped
+          else
+            test "$FAST_GATE_RESULT" = success
+            test "$TEST_LINUX_RESULT" = success
+            test "$TEST_MACOS_RESULT" = success
+            test "$TEST_INSTALL_RESULT" = success
+            test "$RELEASE_SITE_BUILD_RESULT" = success
+          fi

--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -49,7 +49,9 @@ jobs:
               && grep -qi '^content-type: text/html' /tmp/site-headers.txt \
               && curl -fsSL "$SITE_URL/" -o /tmp/site-index.html \
               && grep -q '<main id="main">' /tmp/site-index.html \
-              && grep -q 'https://capsem.org/install.sh' /tmp/site-index.html
+              && grep -q 'Available Summer 2026' /tmp/site-index.html \
+              && curl -fsSL "$SITE_URL/later/" -o /tmp/site-later.html \
+              && grep -q '<main id="main">' /tmp/site-later.html
             then
               echo "capsem.org smoke passed."
               exit 0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Capsem 0.6 is undergoing release qualification. Installation instructions,
 downloadable packages, and detailed documentation are intentionally unavailable
-until the public release.
+until the public release, planned for Summer 2026.
 
 The current documentation status is at **[docs.capsem.org](https://docs.capsem.org/)**.
 

--- a/later/README.md
+++ b/later/README.md
@@ -1,0 +1,59 @@
+<p align="center">
+  <img src="../crates/capsem-app/icons/icon.svg" alt="Capsem" width="120" />
+</p>
+
+<h1 align="center">Capsem</h1>
+
+<p align="center">
+  <strong>The fastest way to ship with AI securely.</strong><br/>
+  Sandbox AI coding agents in hardware-isolated Linux VMs on macOS and Linux.<br/>
+  Full network control, HTTPS inspection, MCP tool routing, and per-session telemetry.
+</p>
+
+<p align="center">
+  <a href="https://github.com/google/capsem/releases/latest"><img src="https://img.shields.io/github/v/release/google/capsem?label=download&color=blue" alt="Latest Release" /></a>
+  <a href="https://codecov.io/gh/google/capsem"><img src="https://codecov.io/gh/google/capsem/graph/badge.svg" alt="Coverage" /></a>
+  <a href="https://github.com/google/capsem/actions/workflows/ci.yaml"><img src="https://github.com/google/capsem/actions/workflows/ci.yaml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/google/capsem/blob/main/LICENSE"><img src="https://img.shields.io/github/license/google/capsem" alt="License" /></a>
+</p>
+
+## Install
+
+```sh
+curl -fsSL https://capsem.org/install.sh | sh
+```
+
+Pre-built binaries (DMG, .deb, .AppImage) are also available from the [latest release](https://github.com/google/capsem/releases/latest). See the [Getting Started](https://capsem.org/getting-started/) guide for details.
+
+## Quick start
+
+```sh
+capsem uname -a
+capsem echo hello
+capsem 'ls -la /proc/cpuinfo'
+```
+
+## Documentation
+
+Full documentation at **[capsem.org](https://capsem.org)**.
+
+| Topic | Link |
+|-------|------|
+| Getting Started | [capsem.org/getting-started](https://capsem.org/getting-started/) |
+| Architecture | [capsem.org/architecture/hypervisor](https://capsem.org/architecture/hypervisor/) |
+| Security | [capsem.org/security/overview](https://capsem.org/security/overview/) |
+| Custom Images | [capsem.org/architecture/custom-images](https://capsem.org/architecture/custom-images/) |
+| Snapshots | [capsem.org/usage/snapshots](https://capsem.org/usage/snapshots/) |
+| Benchmarks | [capsem.org/benchmarks/results](https://capsem.org/benchmarks/results/) |
+| Troubleshooting | [capsem.org/debugging/troubleshooting](https://capsem.org/debugging/troubleshooting/) |
+| Development | [capsem.org/development/getting-started](https://capsem.org/development/getting-started/) |
+| Just Recipes | [capsem.org/development/just-recipes](https://capsem.org/development/just-recipes/) |
+| Release Notes | [capsem.org/releases](https://capsem.org/releases/0-15/) |
+
+## Disclaimer
+
+This project is not an official Google project. It is not supported by Google and Google specifically disclaims all warranties as to its quality, merchantability, or fitness for a particular purpose.
+
+## License
+
+See [LICENSE](../LICENSE).

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,24 +1,41 @@
 ---
 import Base from "../layouts/Base.astro";
 import "../styles/global.css";
-import Nav from "../components/Nav.svelte";
-import Hero from "../components/Hero.svelte";
-import Features from "../components/Features.svelte";
-import ProductOverview from "../components/ProductOverview.svelte";
-import HowItWorks from "../components/HowItWorks.svelte";
-import FAQ from "../components/FAQ.svelte";
-import CTA from "../components/CTA.svelte";
-import Footer from "../components/Footer.svelte";
 ---
 <Base>
-  <Nav client:load />
+  <header class="absolute inset-x-0 top-0 z-10">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <div class="flex items-center gap-2.5">
+        <img src="/logo.svg" alt="" class="h-8 w-8" />
+        <span class="text-lg font-bold tracking-tight text-heading">Capsem</span>
+      </div>
+      <a href="https://github.com/google/capsem" class="btn-dark">GitHub</a>
+    </div>
+  </header>
+
   <main id="main">
-    <Hero />
-    <Features />
-    <ProductOverview />
-    <HowItWorks />
-    <FAQ client:visible />
-    <CTA client:visible />
+    <section class="relative min-h-screen overflow-hidden pt-32 pb-20 md:pt-44 md:pb-32">
+      <div class="absolute inset-0 bg-[linear-gradient(to_right,#e5e7eb_1px,transparent_1px),linear-gradient(to_bottom,#e5e7eb_1px,transparent_1px)] bg-[size:4rem_4rem] opacity-40"></div>
+      <div class="absolute inset-0 bg-[radial-gradient(ellipse_60%_50%_at_50%_-20%,var(--color-accent-glow),transparent)]"></div>
+
+      <div class="relative mx-auto max-w-6xl px-6">
+        <div class="max-w-3xl">
+          <h1 class="text-5xl font-extrabold leading-[1.08] tracking-tight text-heading md:text-7xl">
+            <span class="gradient-text">CAPSEM</span><br />
+            The fastest way to<br />
+            ship with AI securely.
+          </h1>
+
+          <p class="mt-6 max-w-xl text-lg leading-relaxed text-body md:text-xl">
+            A Rust-powered hypervisor that sandboxes every AI coding agent
+            in its own air-gapped Linux VM. See everything, control everything.
+          </p>
+
+          <p class="mt-10 inline-flex rounded-full bg-heading px-6 py-3 text-sm font-semibold text-white">
+            Available Summer 2026
+          </p>
+        </div>
+      </div>
+    </section>
   </main>
-  <Footer />
 </Base>

--- a/site/src/pages/later/index.astro
+++ b/site/src/pages/later/index.astro
@@ -1,0 +1,24 @@
+---
+import Base from "../../layouts/Base.astro";
+import "../../styles/global.css";
+import Nav from "../../components/Nav.svelte";
+import Hero from "../../components/Hero.svelte";
+import Features from "../../components/Features.svelte";
+import ProductOverview from "../../components/ProductOverview.svelte";
+import HowItWorks from "../../components/HowItWorks.svelte";
+import FAQ from "../../components/FAQ.svelte";
+import CTA from "../../components/CTA.svelte";
+import Footer from "../../components/Footer.svelte";
+---
+<Base>
+  <Nav client:load />
+  <main id="main">
+    <Hero />
+    <Features />
+    <ProductOverview />
+    <HowItWorks />
+    <FAQ client:visible />
+    <CTA client:visible />
+  </main>
+  <Footer />
+</Base>

--- a/tests/test_release_doctor_contract.py
+++ b/tests/test_release_doctor_contract.py
@@ -6291,3 +6291,33 @@ def test_release_recipes_reject_a_dirty_tree_before_running_the_gate() -> None:
             f"{recipe} runs the gate before checking the tree, which is the "
             "forty-minute failure this exists to prevent"
         )
+
+
+def test_web_only_prs_do_not_depend_on_product_or_release_jobs() -> None:
+    workflow = _workflow_text("ci.yaml")
+    docs_job = _workflow_job_block("docs-build")
+    gate = _workflow_job_block("pr-gate")
+
+    assert "fetch-depth: 0" in docs_job
+    assert "git diff --name-only \"$BASE_SHA\"...HEAD" in docs_job
+    assert "web_only: ${{ steps.scope.outputs.web_only }}" in docs_job
+    assert "site/*|docs/*" in docs_job
+    assert 'if [ "$EVENT_NAME" != pull_request ]; then' in docs_job
+    assert 'echo "web_only=false"' in docs_job
+
+    for job_name in ("fast-gate", "test-linux", "test", "test-install", "release-site-build"):
+        job = _workflow_job_block(job_name)
+        assert "needs: docs-build" in job
+        assert "needs.docs-build.outputs.web_only != 'true'" in job
+
+    assert "WEB_ONLY: ${{ needs.docs-build.outputs.web_only }}" in gate
+    assert 'if [ "$WEB_ONLY" = true ]; then' in gate
+    for result in (
+        "FAST_GATE_RESULT",
+        "TEST_LINUX_RESULT",
+        "TEST_MACOS_RESULT",
+        "TEST_INSTALL_RESULT",
+        "RELEASE_SITE_BUILD_RESULT",
+    ):
+        assert f'test "${result}" = skipped' in gate
+        assert f'test "${result}" = success' in gate


### PR DESCRIPTION
## Summary

- keep the marketing site's existing visual language and hero tagline
- replace install/download actions with “Available Summer 2026”
- remove lower marketing sections from the public root
- preserve the complete marketing page at `/later/` for continued rework
- preserve the former README under `later/README.md`
- update the README’s existing safe pre-release notice with the Summer 2026 target
- update the marketing deployment smoke check for the temporary root and `/later/`

## Why

Capsem does not yet have a valid public release. The marketing surface must not send users toward unavailable downloads while initial-release qualification is underway.

The branch was rebased over the production agent’s new documentation holding/tombstone work. Those no-store route protections and their smoke checks remain unchanged.

## Validation

- `pnpm --dir site run build`
- `pnpm --dir docs run build` including the holding-artifact verifier
- `uv run pytest -q tests/test_docs_holding_contract.py ...` — 13 passed
- `git diff --check`
