### PR TITLE
Keep staged content under site

### DIFF
--- a/site/later/README.md
+++ b/site/later/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../crates/capsem-app/icons/icon.svg" alt="Capsem" width="120" />
+  <img src="../../crates/capsem-app/icons/icon.svg" alt="Capsem" width="120" />
 </p>
 
 <h1 align="center">Capsem</h1>
@@ -56,4 +56,4 @@ This project is not an official Google project. It is not supported by Google an
 
 ## License
 
-See [LICENSE](../LICENSE).
+See [LICENSE](../../LICENSE).


### PR DESCRIPTION
## Summary

Move the preserved README from the repository-root `later/` directory to `site/later/`.

All temporary website work now stays under `site/`; the repository root no longer gains a staging directory.

## Validation

- `git diff --check`
- relative logo and license links updated for the new location
